### PR TITLE
Introduce cquery support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ for the language of your choice. Otherwise, it prompts you to enter one:
 * Python's [pyls][pyls]
 * Bash's [bash-language-server][bash-language-server]
 * PHP's [php-language-server][php-language-server]
+* [cquery][cquery] for C/C++
+
 
 I'll add to this list as I test more servers. In the meantime you can
 customize `eglot-server-programs`:
@@ -196,5 +198,7 @@ Under the hood:
 [bash-language-server]: https://github.com/mads-hartmann/bash-language-server
 [php-language-server]: https://github.com/felixfbecker/php-language-server
 [company-mode]: https://github.com/company-mode/company-mode
+[cquery]: https://github.com/cquery-project/cquery
+
 
    

--- a/eglot.el
+++ b/eglot.el
@@ -1038,7 +1038,7 @@ function with the server still running."
   "Unreported diagnostics for this buffer.")
 
 (cl-defmethod eglot-handle-notification
-  (_server (_method (eql :textDocument/publishDiagnostics)) &key uri diagnostics)
+  (server (_method (eql :textDocument/publishDiagnostics)) &key uri diagnostics)
   "Handle notification publishDiagnostics"
   (if-let ((buffer (find-buffer-visiting (eglot--uri-to-path uri))))
       (with-current-buffer buffer
@@ -1060,7 +1060,7 @@ function with the server still running."
                         (setq eglot--unreported-diagnostics nil))
                        (t
                         (setq eglot--unreported-diagnostics diags)))))
-    (eglot--warn "Diagnostics received for unvisited %s" uri)))
+    (eglot--debug server "Diagnostics received for unvisited %s" uri)))
 
 (cl-defun eglot--register-unregister (server jsonrpc-id things how)
   "Helper for `registerCapability'.

--- a/eglot.el
+++ b/eglot.el
@@ -774,6 +774,10 @@ DEFERRED is passed to `eglot--async-request', which see."
   (let ((warning-minimum-level :error))
     (display-warning 'eglot (apply #'format format args) :warning)))
 
+(defun eglot--debug (server format &rest args)
+  "Warning message with FORMAT and ARGS."
+  (eglot--log-event server `(:message ,(format format args))))
+
 (defun eglot--pos-to-lsp-position (&optional pos)
   "Convert point POS to LSP position."
   (save-excursion


### PR DESCRIPTION
With these two patches I've got `cquery` up and running via `eglot`. Still have a few rough edges to hash out before this is ready to merge:

- [x] Currently the per-process variables are accessed by internal methods (i.e. `(cquery--init-opts)`) rather than public functions. 
- [x] `cquery` seems fond of sending diagnostics for buffers that haven't been visited. ~I need to figure out whether or not this is part of the LSP spec or not and then write patches for the culprit.~ This seems to be allowed by the [`publishDiagnostics`](https://microsoft.github.io/language-server-protocol/specification#textDocument_publishDiagnostics) spec.
- [x] ~I'd like minimal integration with `hide-ifdef-mode`, although that might end up needing a `defadvice` or upstream patch to the mode to avoid it clashing with the built-in parser. If that's the case I'll defer that to… well, either an external package or an `init.el` hack.~ Too invasive for `eglot.el`, I'll defer the to an add-on package after the process-local variable API is reworked.
- [x] `cquery` is [sending back an extra key for DocumentHighlight requests](https://github.com/joaotavora/eglot/pull/6#issuecomment-390797813) that doesn't seem to be in the language server spec. Fixed in [cquery#682](https://github.com/cquery-project/cquery/issues/682).

I have copyright attribution papers on file with the Emacs project. Apologies if I got the commit message format wrong, I had to read up on the style.