### PR TITLE
Use GitHub Flavored Markdown (GFM) for formatted strings

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -847,7 +847,7 @@ If optional MARKER, return a marker instead"
   "Format MARKUP according to LSP's spec."
   (pcase-let ((`(,string ,mode)
                (if (stringp markup) (list (string-trim markup)
-                                          (intern "markdown-mode"))
+                                          (intern "gfm-mode"))
                  (list (plist-get markup :value)
                        (intern (concat (plist-get markup :language) "-mode" ))))))
     (with-temp-buffer


### PR DESCRIPTION
Currently, by default `markdown-mode` is used to render Markdown-formatted text from the remote language server. This results in confusing renderings when function or variable names contain underscores -- see the below screenshot of help text from the Python language server: 
<img width="435" alt="screen shot 2018-06-16 at 17 52 13" src="https://user-images.githubusercontent.com/460769/41502740-40d0322c-718f-11e8-94d5-a9fde84fcc31.png">

Using `gfm-mode` instead fixes this:
<img width="462" alt="screen shot 2018-06-16 at 17 52 38" src="https://user-images.githubusercontent.com/460769/41502739-3adcd956-718f-11e8-8614-69328fd4f9ed.png">

`gfm-mode` seems to be the recommended way for Emacs buffers to render this style of Markdown [according to the Markdown-mode documentation](https://jblevins.org/projects/markdown-mode/). Since `gfm-mode` is provided by the same package as `markdown-mode`, this shouldn't create any additional dependency issues.


