### PR TITLE
Fix typo in the solargraph server program

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -86,7 +86,7 @@
                                 ((c++-mode
                                   c-mode) . (eglot-cquery "cquery"))
                                 (ruby-mode
-                                 . ("solagraph" "socket" "--port"
+                                 . ("solargraph" "socket" "--port"
                                     :autoport))
                                 (php-mode . ("php" "vendor/felixfbecker/\
 language-server/bin/php-language-server.php")))


### PR DESCRIPTION
Here's a very, very small contribution: the solargraph LSP server listed in the list of server programs has a typo, which prevented it from ever launching successfully.

By the way, I'd like to say thank you for your work on this package!