### PR TITLE
Format documentation in completion annotations

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1227,7 +1227,7 @@ DUMMY is ignored."
              (text-properties-at 0 obj)
            (let ((annotation
                   (or (and documentation
-                           (replace-regexp-in-string "\n.*" "" documentation))
+                           (replace-regexp-in-string "\n.*" "" (eglot--format-markup documentation)))
                       detail
                       (cdr (assoc kind eglot--kind-names)))))
              (when annotation


### PR DESCRIPTION
Fixes an issue with the latest RLS, where the server returns a plist instead of a plain string as documentation for completion candidates, which broke the `annotation-function`. This change was introduced by https://github.com/rust-lang-nursery/rls/commit/206a9fb41e837333d0e67187a6a9fe24868b77a4