### PR TITLE
Close #29: Implement workspace/didChangeConfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ Here's a summary of available commands:
 - `M-x eglot-stderr-buffer` if the LSP server is printing useful debug
 information in stderr, jumps to a buffer with these contents.
 
+- `M-x eglot-signal-didChangeConfiguration` updates the LSP server
+configuration according to the value of the variable
+`eglot-workspace-configuration`, which you may, for example set in a
+`.dir-locals` file.`
+
 There are *no keybindings* specific to Eglot, but you can bind stuff
 in `eglot-mode-map`, which is active as long as Eglot is managing a
 file in your project. The commands don't need to be Eglot-specific,
@@ -163,7 +168,7 @@ eglot-shutdown`.
 ## Workspace
 - [ ] workspace/workspaceFolders (3.6.0)
 - [ ] workspace/didChangeWorkspaceFolders (3.6.0)
-- [ ] workspace/didChangeConfiguration
+- [x] workspace/didChangeConfiguration
 - [ ] workspace/configuration (3.6.0)
 - [x] workspace/didChangeWatchedFiles
 - [x] workspace/symbol

--- a/eglot.el
+++ b/eglot.el
@@ -445,6 +445,11 @@ INTERACTIVE is t if called interactively."
 
 (defvar eglot-connect-hook nil "Hook run after connecting in `eglot--connect'.")
 
+(defvar eglot-server-initialized-hook
+  '(eglot-signal-didChangeConfiguration)
+  "Hook run after server is successfully initialized.
+Each function is passed the server as an argument")
+
 (defun eglot--connect (managed-major-mode project class contact)
   "Connect to MANAGED-MAJOR-MODE, PROJECT, CLASS and CONTACT.
 This docstring appeases checkdoc, that's all."
@@ -515,6 +520,7 @@ This docstring appeases checkdoc, that's all."
             (with-current-buffer buffer
               (eglot--maybe-activate-editing-mode server)))
           (jsonrpc-notify server :initialized `(:__dummy__ t))
+          (run-hook-with-args 'eglot-server-initialized-hook server)
           (setf (eglot--inhibit-autoreconnect server)
                 (cond
                  ((booleanp eglot-autoreconnect) (not eglot-autoreconnect))
@@ -1006,6 +1012,22 @@ Records START, END and PRE-CHANGE-LENGTH locally."
                            (when (and eglot--managed-mode deferred)
                              (eglot--signal-textDocument/didChange))))
             '((name . eglot--signal-textDocument/didChange)))
+
+(defvar-local eglot-workspace-configuration ()
+  "Alist of (SETTING . VALUE) entries configuring the LSP server.
+Setting should be a keyword, value can be any value that can be
+converted to JSON.")
+
+(defun eglot-signal-didChangeConfiguration (server)
+  "Send a `:workspace/didChangeConfiguration' signal to SERVER.
+When called interactively, use the currently active server"
+  (interactive (list (eglot--current-server-or-lose)))
+  (jsonrpc-notify
+   server :workspace/didChangeConfiguration
+   (list
+    :settings
+    (cl-loop for (k . v) in eglot-workspace-configuration
+             collect k collect v))))
 
 (defun eglot--signal-textDocument/didChange ()
   "Send textDocument/didChange to server."


### PR DESCRIPTION
* README.md (Supported Protocol Features, Commands and
keybindings): mention workspace/didChangeConfiguration.

* eglot.el (eglot-server-initialized-hook): New hook.
(eglot--connect): Run it.
(eglot-workspace-configuration): New variable.
(eglot-signal-didChangeConfiguration): New command.