### PR TITLE
Implement TextDocument/rangeFormatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ Here's a summary of available commands:
 
 - `M-x eglot-rename` ask the server to rename the symbol at point;
 
-- `M-x eglot-format-buffer` ask the server to reformat the current
-  buffer;
+- `M-x eglot-format` asks the server to format buffer or the active
+  region;
 
 - `M-x eglot-code-actions` asks the server for any code actions at
   point. These may tipically be simple fixes, like deleting an unused
@@ -206,7 +206,7 @@ eglot-shutdown`.
 - [ ] textDocument/documentColor
 - [ ] textDocument/colorPresentation (3.6.0)
 - [x] textDocument/formatting 
-- [ ] textDocument/rangeFormatting
+- [x] textDocument/rangeFormatting
 - [ ] textDocument/onTypeFormatting
 - [x] textDocument/rename
 

--- a/eglot.el
+++ b/eglot.el
@@ -1438,7 +1438,23 @@ If SKIP-SIGNATURE, don't try to send textDocument/signatureHelp."
                       (save-excursion
                         (save-restriction
                           (narrow-to-region beg end)
-                          (replace-buffer-contents temp)))
+
+                          ;; On emacs versions < 26.2,
+                          ;; `replace-buffer-contents' is buggy - it calls
+                          ;; change functions with invalid arguments - so we
+                          ;; manually call the change functions here.
+                          ;;
+                          ;; See emacs bugs #32237, #32278:
+                          ;; https://debbugs.gnu.org/cgi/bugreport.cgi?bug=32237
+                          ;; https://debbugs.gnu.org/cgi/bugreport.cgi?bug=32278
+                          (let ((inhibit-modification-hooks t)
+                                (length (- end beg)))
+                            (run-hook-with-args 'before-change-functions
+                                                beg end)
+                            (replace-buffer-contents temp)
+                            (run-hook-with-args 'after-change-functions
+                                                beg (+ beg (length newText))
+                                                length))))
                       (progress-reporter-update reporter (cl-incf done)))))))
             (mapcar (jsonrpc-lambda (&key range newText)
                       (cons newText (eglot--range-region range 'markers)))


### PR DESCRIPTION
This commit implements the TextDocument/rangeFormatting method.

I have already signed and sent the FSF copyright assignment papers, but unfortunately the copyright clerk left FSF soon after that, so it will probably take a while until the whole process is finished.