### PR TITLE
Work around Emacs bugs 32237, 32278

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1438,7 +1438,23 @@ If SKIP-SIGNATURE, don't try to send textDocument/signatureHelp."
                       (save-excursion
                         (save-restriction
                           (narrow-to-region beg end)
-                          (replace-buffer-contents temp)))
+
+                          ;; On emacs versions < 26.2,
+                          ;; `replace-buffer-contents' is buggy - it calls
+                          ;; change functions with invalid arguments - so we
+                          ;; manually call the change functions here.
+                          ;;
+                          ;; See emacs bugs #32237, #32278:
+                          ;; https://debbugs.gnu.org/cgi/bugreport.cgi?bug=32237
+                          ;; https://debbugs.gnu.org/cgi/bugreport.cgi?bug=32278
+                          (let ((inhibit-modification-hooks t)
+                                (length (- end beg)))
+                            (run-hook-with-args 'before-change-functions
+                                                beg end)
+                            (replace-buffer-contents temp)
+                            (run-hook-with-args 'after-change-functions
+                                                beg (+ beg (length newText))
+                                                length))))
                       (progress-reporter-update reporter (cl-incf done)))))))
             (mapcar (jsonrpc-lambda (&key range newText)
                       (cons newText (eglot--range-region range 'markers)))


### PR DESCRIPTION
See:
https://debbugs.gnu.org/cgi/bugreport.cgi?bug=32237
https://debbugs.gnu.org/cgi/bugreport.cgi?bug=32278

* eglot.el (eglot--apply-text-edits): Inhibit modification hooks and
  call them manually for the changed region.