### PR TITLE
Fix diagnostics placed in wrong place when diag.start == diag.end

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -929,8 +929,8 @@ Uses THING, FACE, DEFS and PREPEND."
                          (let* ((st (plist-get range :start))
                                 (diag-region
                                  (flymake-diag-region
-                                  (current-buffer) (plist-get st :line)
-                                  (1- (plist-get st :character)))))
+                                  (current-buffer) (1+ (plist-get st :line))
+                                  (plist-get st :character))))
                            (setq beg (car diag-region)
                                  end (cdr diag-region))))
                      (eglot--make-diag (current-buffer) beg end


### PR DESCRIPTION
* eglot.el (eglot-handle-notification
  :textDocument/publishDiagnostics): Add 1 to :line since LSP lines
  are 0-based.  Don't subtract 1 from :character, since both emacs and
  LSP have 0-based columns.