### PR TITLE
Fix more bugs in eglot--apply-text-edits

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1468,7 +1468,9 @@ If SKIP-SIGNATURE, don't try to send textDocument/signatureHelp."
                           ;; https://debbugs.gnu.org/cgi/bugreport.cgi?bug=32237
                           ;; https://debbugs.gnu.org/cgi/bugreport.cgi?bug=32278
                           (let ((inhibit-modification-hooks t)
-                                (length (- end beg)))
+                                (length (- end beg))
+                                (beg (marker-position beg))
+                                (end (marker-position end)))
                             (run-hook-with-args 'before-change-functions
                                                 beg end)
                             (replace-buffer-contents temp)
@@ -1478,7 +1480,10 @@ If SKIP-SIGNATURE, don't try to send textDocument/signatureHelp."
                       (progress-reporter-update reporter (cl-incf done)))))))
             (mapcar (jsonrpc-lambda (&key range newText)
                       (cons newText (eglot--range-region range 'markers)))
-                    edits))
+                    ;; Reverse the edits so that if there are multiple
+                    ;; insertions in the same place, they appear in the buffer
+                    ;; in the original order, as per the standard.
+                    (nreverse edits)))
       (undo-amalgamate-change-group change-group)
       (progress-reporter-done reporter))))
 


### PR DESCRIPTION
This fixes bugs which I found when using the eclipse.jdt.ls server. If there are multiple insertions in the same place, the inserted text must be in the same order as the TextEdit[] array itself. https://microsoft.github.io/language-server-protocol/specification#textedit-1

To reproduce it, simply run the eclipse.jdt.ls server without this fix and try some code actions.
