### PR TITLE
Fix wrong-type-argument when MarkedString is a plist

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1353,8 +1353,7 @@ is not active."
   (let ((heading (and range (pcase-let ((`(,beg . ,end) (eglot--range-region range)))
                               (concat (buffer-substring beg end)  ": "))))
         (body (mapconcat #'eglot--format-markup
-                         (append (cond ((vectorp contents) contents)
-                                       ((stringp contents) (list contents)))) "\n")))
+                         (if (vectorp contents) contents (list contents)) "\n")))
     (when (or heading (cl-plusp (length body))) (concat heading body))))
 
 (defun eglot--sig-info (sigs active-sig active-param)


### PR DESCRIPTION
In `eglot--hover-info` we weren't handling the case when MarkedString is a plist. This leads to `wrong-type-argument`, e.g when a class has no documentation and we call `eglot-help-at-point` when using eclipse.jdt.ls.

```
Debugger entered--Lisp error: (wrong-type-argument char-or-string-p nil)
  insert(nil)
  (save-current-buffer (set-buffer standard-output) (insert blurb))
  (progn (save-current-buffer (set-buffer standard-output) (insert blurb)))
  (progn (progn (save-current-buffer (set-buffer standard-output) (insert blurb))))
  (setq #:value (progn (progn (save-current-buffer (set-buffer standard-output) (insert blurb)))))
  (let* ((#:buffer (temp-buffer-window-setup "*eglot help*")) (standard-output #:buffer) #:window #:value) (setq #:value (progn (progn (save-current-buffer (set-buffer standard-output) (insert blurb))))) (save-current-buffer (set-buffer #:buffer) (setq #:window (temp-buffer-window-show #:buffer nil))) (if (functionp (quote help-window-setup)) (funcall (quote help-window-setup) #:window #:value) #:value))
  (let ((temp-buffer-window-setup-hook (cons (quote help-mode-setup) temp-buffer-window-setup-hook)) (temp-buffer-window-show-hook (cons (quote help-mode-finish) temp-buffer-window-show-hook))) (setq help-window-old-frame (selected-frame)) (let* ((#:buffer (temp-buffer-window-setup "*eglot help*")) (standard-output #:buffer) #:window #:value) (setq #:value (progn (progn (save-current-buffer (set-buffer standard-output) (insert blurb))))) (save-current-buffer (set-buffer #:buffer) (setq #:window (temp-buffer-window-show #:buffer nil))) (if (functionp (quote help-window-setup)) (funcall (quote help-window-setup) #:window #:value) #:value)))
  (progn (set-marker help-window-point-marker nil) (let ((temp-buffer-window-setup-hook (cons (quote help-mode-setup) temp-buffer-window-setup-hook)) (temp-buffer-window-show-hook (cons (quote help-mode-finish) temp-buffer-window-show-hook))) (setq help-window-old-frame (selected-frame)) (let* ((#:buffer (temp-buffer-window-setup "*eglot help*")) (standard-output #:buffer) #:window #:value) (setq #:value (progn (progn (save-current-buffer (set-buffer standard-output) (insert blurb))))) (save-current-buffer (set-buffer #:buffer) (setq #:window (temp-buffer-window-show #:buffer nil))) (if (functionp (quote help-window-setup)) (funcall (quote help-window-setup) #:window #:value) #:value))))
  (let ((blurb (eglot--hover-info contents range))) (progn (set-marker help-window-point-marker nil) (let ((temp-buffer-window-setup-hook (cons (quote help-mode-setup) temp-buffer-window-setup-hook)) (temp-buffer-window-show-hook (cons (quote help-mode-finish) temp-buffer-window-show-hook))) (setq help-window-old-frame (selected-frame)) (let* ((#:buffer (temp-buffer-window-setup "*eglot help*")) (standard-output #:buffer) #:window #:value) (setq #:value (progn (progn (save-current-buffer ... ...)))) (save-current-buffer (set-buffer #:buffer) (setq #:window (temp-buffer-window-show #:buffer nil))) (if (functionp (quote help-window-setup)) (funcall (quote help-window-setup) #:window #:value) #:value)))))
  (progn (let ((#:--cl-keys-- #:--cl-rest--)) (while #:--cl-keys-- (cond ((memq (car #:--cl-keys--) (quote (:contents :range :allow-other-keys))) (setq #:--cl-keys-- (cdr (cdr #:--cl-keys--)))) ((car (cdr (memq ... #:--cl-rest--))) (setq #:--cl-keys-- nil)) (t (error "Keyword argument %s not one of (:contents :range)" (car #:--cl-keys--)))))) (if (seq-empty-p contents) (progn (eglot--error "No hover info here"))) (let ((blurb (eglot--hover-info contents range))) (progn (set-marker help-window-point-marker nil) (let ((temp-buffer-window-setup-hook (cons (quote help-mode-setup) temp-buffer-window-setup-hook)) (temp-buffer-window-show-hook (cons (quote help-mode-finish) temp-buffer-window-show-hook))) (setq help-window-old-frame (selected-frame)) (let* ((#:buffer (temp-buffer-window-setup "*eglot help*")) (standard-output #:buffer) #:window #:value) (setq #:value (progn (progn ...))) (save-current-buffer (set-buffer #:buffer) (setq #:window (temp-buffer-window-show #:buffer nil))) (if (functionp (quote help-window-setup)) (funcall (quote help-window-setup) #:window #:value) #:value))))))
  (let* ((#:--cl-rest-- (jsonrpc-request (eglot--current-server-or-lose) :textDocument/hover (eglot--TextDocumentPositionParams))) (contents (car (cdr (plist-member #:--cl-rest-- (quote :contents))))) (range (car (cdr (plist-member #:--cl-rest-- (quote :range)))))) (progn (let ((#:--cl-keys-- #:--cl-rest--)) (while #:--cl-keys-- (cond ((memq (car #:--cl-keys--) (quote ...)) (setq #:--cl-keys-- (cdr ...))) ((car (cdr ...)) (setq #:--cl-keys-- nil)) (t (error "Keyword argument %s not one of (:contents :range)" (car #:--cl-keys--)))))) (if (seq-empty-p contents) (progn (eglot--error "No hover info here"))) (let ((blurb (eglot--hover-info contents range))) (progn (set-marker help-window-point-marker nil) (let ((temp-buffer-window-setup-hook (cons ... temp-buffer-window-setup-hook)) (temp-buffer-window-show-hook (cons ... temp-buffer-window-show-hook))) (setq help-window-old-frame (selected-frame)) (let* ((#:buffer ...) (standard-output #:buffer) #:window #:value) (setq #:value (progn ...)) (save-current-buffer (set-buffer #:buffer) (setq #:window ...)) (if (functionp ...) (funcall ... #:window #:value) #:value)))))))
  eglot-help-at-point()```