### PR TITLE
Make it possible to select server to shut down from eglot-shutdown

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -244,7 +244,9 @@ If PRESERVE-BUFFERS is non-nil (interactively, when called with a
 prefix argument), do not kill events and output buffers of
 SERVER.  Don't leave this function with the server still
 running."
-  (interactive (list (eglot--current-server-or-lose) t nil current-prefix-arg))
+  (interactive (list
+                (eglot--read-server "Shut down server: ")
+                t nil current-prefix-arg))
   (eglot--message "Asking %s politely to terminate" (jsonrpc-name server))
   (unwind-protect
       (progn
@@ -294,6 +296,20 @@ running."
                 (when (plist-member (symbol-plist sym) 'derived-mode-parent)
                   (push sym retval))))
     retval))
+
+(defun eglot--read-server (prompt)
+  "Read a server from the minibuffer with PROMPT."
+  (let ((alist
+         (mapcar
+          (lambda (server) (cons (jsonrpc-name server) server))
+          (delq nil
+                (cons (eglot--current-server)
+                      (apply #'append
+                             (hash-table-values eglot--servers-by-project)))))))
+    (cdr
+     (assoc
+      (completing-read prompt (delete-dups alist) nil t nil nil (car alist))
+      alist))))
 
 (defvar eglot--command-history nil
   "History of CONTACT arguments to `eglot'.")


### PR DESCRIPTION
This commit makes the command `eglot-shutdown` ask the user for server to kill when it's called with a prefix argument. I find the current workflow for killing servers a little bit awkward (switch to project, switch to some file managed by the server, kill it). This IMO improves this workflow.