### PR TITLE
Add go-langserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ for the language of your choice. Otherwise, it prompts you to enter one:
 * C/C++'s [cquery][cquery]
 * Haskell's [IDE engine][haskell-ide-engine]
 * Kotlin's [kotlin-language-server][kotlin-language-server]
+* Golang's [go-langserver][go-langserver]
 
 I'll add to this list as I test more servers. In the meantime you can
 customize `eglot-server-programs`:
@@ -288,4 +289,5 @@ Under the hood:
 [windows-subprocess-hang]: https://www.gnu.org/software/emacs/manual/html_node/efaq-w32/Subprocess-hang.html
 [haskell-ide-engine]: https://github.com/haskell/haskell-ide-engine
 [kotlin-language-server]: https://github.com/fwcd/KotlinLanguageServer
+[go-langserver]: https://github.com/sourcegraph/go-langserver
 

--- a/eglot.el
+++ b/eglot.el
@@ -91,7 +91,8 @@
                                 (php-mode . ("php" "vendor/felixfbecker/\
 language-server/bin/php-language-server.php"))
                                 (haskell-mode . ("hie-wrapper"))
-                                (kotlin-mode . ("kotlin-language-server")))
+                                (kotlin-mode . ("kotlin-language-server"))
+                                (go-mode . ("go-langserver" "-mode=stdio" "-gocodecompletion")))
   "How the command `eglot' guesses the server to start.
 An association list of (MAJOR-MODE . CONTACT) pairs.  MAJOR-MODE
 is a mode symbol, or a list of mode symbols.  The associated


### PR DESCRIPTION
This PR adds auto-detection for go-mode buffers utilizing https://github.com/sourcegraph/go-langserver.

