### PR TITLE
Ignore extra keys in textDocument/publishDiagnostics

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1036,7 +1036,8 @@ COMMAND is a symbol naming the command."
         (cl-loop
          for diag-spec across diagnostics
          collect (cl-destructuring-bind (&key range ((:severity sev)) _group
-                                              _code source message)
+                                              _code source message
+                                              &allow-other-keys)
                      diag-spec
                    (setq message (concat source ": " message))
                    (pcase-let


### PR DESCRIPTION
clangd recently started including `:category` in it's diagnostic notification. According to the comments in the [review](https://reviews.llvm.org/D50571) of the change that introduced this VSCode is fine with this extension.