### PR TITLE
When exiting emacs, don't ask the user to confirm killing processes

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -513,6 +513,7 @@ This docstring appeases checkdoc, that's all."
                                 :command contact
                                 :connection-type 'pipe
                                 :coding 'utf-8-emacs-unix
+                                :noquery t
                                 :stderr (get-buffer-create
                                          (format "*%s stderr*" readable-name))))))))
          (spread
@@ -627,6 +628,7 @@ CONNECT-ARGS are passed as additional arguments to
                 (make-process
                  :name (format "autostart-inferior-%s" name)
                  :stderr (format "*%s stderr*" name)
+                 :noquery t
                  :command (cl-subst
                            (format "%s" port-number) :autoport contact)))
           (setq connection


### PR DESCRIPTION
* eglot.el (eglot--connect): pass `noquery t` to `make-process`
* eglot.el (eglot--inferior-bootstrap): pass `noquery t` to `make-process`

I'm not sure if you agree with this.

I personally don't like being prompted whether I'm OK with processes I didn't start myself getting killed. Flyspell for example doesn't prompt.