### PR TITLE
Don't warning on $ implementation dependent notifications

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -987,7 +987,8 @@ Uses THING, FACE, DEFS and PREPEND."
 (cl-defmethod eglot-handle-notification
   (_server method &key &allow-other-keys)
   "Handle unknown notification"
-  (eglot--warn "Server sent unknown notification method `%s'" method))
+  (unless (string-prefix-p "$" method)
+    (eglot--warn "Server sent unknown notification method `%s'" method)))
 
 (cl-defmethod eglot-handle-request
   (_server method &key &allow-other-keys)


### PR DESCRIPTION
https://microsoft.github.io/language-server-protocol/specification

> Notification and requests whose methods start with ‘$/’ are messages which are protocol implementation dependent and might not be implementable in all clients or servers. 
> 
> If a server or client receives notifications or requests starting with ‘$/’ it is free to ignore them if they are unknown.

I incline to just not warning in this case as many of such notifications are informative (e.g. status update) or to provide optional features (e.g. `$ccls/publishSemanticHighlighting`). They will not subvert the protocol.