### PR TITLE
Don't send notifications prior to initialized

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -559,10 +559,10 @@ This docstring appeases checkdoc, that's all."
                           (push server
                                 (gethash project eglot--servers-by-project))
                           (setf (eglot--capabilities server) capabilities)
+                          (jsonrpc-notify server :initialized `(:__dummy__ t))
                           (dolist (buffer (buffer-list))
                             (with-current-buffer buffer
                               (eglot--maybe-activate-editing-mode server)))
-                          (jsonrpc-notify server :initialized `(:__dummy__ t))
                           (setf (eglot--inhibit-autoreconnect server)
                                 (cond
                                  ((booleanp eglot-autoreconnect)


### PR DESCRIPTION
closes #100 

Have zero idea what I am doing, but this seems logical, and all the tests are passing.