### PR TITLE
Add option 'eglot-show-hover-help-p'

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -163,6 +163,13 @@ let the buffer grow forever."
   :type '(choice (const :tag "No limit" nil)
                  (integer :tag "Number of characters")))
 
+(defcustom eglot-show-hover-help-p nil
+  "Control show help documentation when cursor hover.
+
+If is non-nil, show help documentation in minibuffer.
+Default is nil."
+  :type 'boolean)
+
 ;;; API (WORK-IN-PROGRESS!)
 ;;;
 (cl-defmacro eglot--with-live-buffer (buf &rest body)
@@ -1539,7 +1546,8 @@ If SKIP-SIGNATURE, don't try to send textDocument/signatureHelp."
                                               activeSignature
                                               activeParameter)))))
          :deferred :textDocument/signatureHelp))
-      (when (eglot--server-capable :hoverProvider)
+      (when (and eglot-show-hover-help-p
+                 (eglot--server-capable :hoverProvider))
         (jsonrpc-async-request
          server :textDocument/hover position-params
          :success-fn (jsonrpc-lambda (&key contents range)


### PR DESCRIPTION
Hi João

Eglot is awesome, but i don't like it show help document in minibuffer when cursor hover string.

So i add option 'eglot-show-hover-help-p' to control whether show help document when cursor hover.

Thanks you for your great job!