### PR TITLE
Truncate hovering information in echo area

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1548,7 +1548,8 @@ If SKIP-SIGNATURE, don't try to send textDocument/signatureHelp."
                           (when-let (info (and contents
                                                (eglot--hover-info contents
                                                                   range)))
-                            (eldoc-message info)))))
+                            (let ((message-truncate-lines t))
+                              (eldoc-message info))))))
          :deferred :textDocument/hover))
       (when (eglot--server-capable :documentHighlightProvider)
         (jsonrpc-async-request


### PR DESCRIPTION
Currently, hovering symbols with multiple lines of hover-info makes the echo area jump around a bit much.

I'm not sure if this should be customizable, we could check `eldoc-echo-area-use-multiline-p`, but I'd like this behavior only for hovering, and not for signatureHelp.