### PR TITLE
Provide trigger character to LSP server

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -203,6 +203,7 @@ let the buffer grow forever."
                                :dynamicRegistration :json-false
                                :willSave t :willSaveWaitUntil t :didSave t)
              :completion      (list :dynamicRegistration :json-false
+                                    :contextSupport :json-false
                                     :completionItem
                                     `(:snippetSupport
                                       ,(if (eglot--snippet-expansion-fn)


### PR DESCRIPTION
Some LSP servers provide trigger characters. This PR sends the character that triggered the completion to the server if it's supported.