### PR TITLE
Add autoload cookie for `eglot-ensure`.

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -446,6 +446,7 @@ INTERACTIVE is t if called interactively."
 
 (defvar eglot--managed-mode) ; forward decl
 
+;;;###autoload
 (defun eglot-ensure ()
   "Start Eglot session for current buffer if there isn't one."
   (let ((buffer (current-buffer)))


### PR DESCRIPTION
Hi,

Since we recommend to use `eglot-ensure` in hook in README:

```lisp
  (add-hook 'foo-mode-hook 'eglot-ensure)
```

I think we should add the autoload cookie to it, to avoid the error:

    File mode specification error: (void-function eglot-ensure)
