### PR TITLE
Improve signature help

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1521,23 +1521,41 @@ is not active."
 (defun eglot--sig-info (sigs active-sig active-param)
   (cl-loop
    for (sig . moresigs) on (append sigs nil) for i from 0
-   concat (cl-destructuring-bind (&key label _documentation parameters) sig
-            (let (active-doc)
-              (concat
-               (propertize (replace-regexp-in-string "(.*$" "(" label)
-                           'face 'font-lock-function-name-face)
-               (cl-loop
-                for (param . moreparams) on (append parameters nil) for j from 0
-                concat (cl-destructuring-bind (&key label documentation) param
-                         (when (and (eql j active-param) (eql i active-sig))
-                           (setq label (propertize
-                                        label
-                                        'face 'eldoc-highlight-function-argument))
-                           (when documentation
-                             (setq active-doc (concat label ": " documentation))))
-                         label)
-                if moreparams concat ", " else concat ")")
-               (when active-doc (concat "\n" active-doc)))))
+   concat (cl-destructuring-bind (&key label documentation parameters) sig
+            (with-temp-buffer
+              (save-excursion (insert label))
+              (when (looking-at "\\([^(]+\\)(")
+                (add-face-text-property (match-beginning 1) (match-end 1)
+                                        'font-lock-function-name-face))
+
+              (when (and (stringp documentation) (eql i active-sig)
+                         (string-match "[[:space:]]*\\([^.\r\n]+[.]?\\)"
+                                       documentation))
+                (setq documentation (match-string 1 documentation))
+                (unless (string-prefix-p (string-trim documentation) label)
+                  (goto-char (point-max))
+                  (insert ": " documentation)))
+              (when (and (eql i active-sig) active-param
+                         (< -1 active-param (length parameters)))
+                (cl-destructuring-bind (&key label documentation)
+                    (aref parameters active-param)
+                  (goto-char (point-min))
+                  (let ((case-fold-search nil))
+                    (cl-loop for nmatches from 0
+                             while (and (not (string-empty-p label))
+                                        (search-forward label nil t))
+                             finally do
+                             (when (= 1 nmatches)
+                               (add-face-text-property
+                                (- (point) (length label)) (point)
+                                'eldoc-highlight-function-argument))))
+                  (when documentation
+                    (goto-char (point-max))
+                    (insert "\n"
+                            (propertize
+                             label 'face 'eldoc-highlight-function-argument)
+                            ": " documentation))))
+              (buffer-string)))
    when moresigs concat "\n"))
 
 (defun eglot-help-at-point ()


### PR DESCRIPTION
Fixes #97.

I hope this improves the existing signature help format.
It does a couple of things:
1. It makes sure that no information provided by the server is lost, previously signatures were lost in some cases (e.g. with clangd, `foo(int a) -> std::string` was transformed to `foo(int a)`)
2. It fixes the case when the parameter list was empty and the ending `)` was not appended (e.g. `foo() -> void` was transformed to `foo(`
3. It handles the case when signature label does not match `.*(` regexp. For example, previously the signature help for python's `len()` function was shown because of this as: `Return the number of items in a container.obj)`
4. It appends the first sentence of documentation to the result, if available
5. It highlights the parameters by searching for their `:label` in the signature's `:label`. This mostly works, although not always, especially in dynamic languages. IMO it's better than the previous implementation, though.