### PR TITLE
Tolerate other keys in textDocument/documentSymbol

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1348,7 +1348,7 @@ DUMMY is ignored."
          (setq eglot--xref-known-symbols
                (mapcar
                 (jsonrpc-lambda
-                    (&key name kind location containerName)
+                    (&key name kind location containerName &allow-other-keys)
                   (propertize name
                               :textDocumentPositionParams
                               (list :textDocument text-id
@@ -1656,7 +1656,7 @@ If SKIP-SIGNATURE, don't try to send textDocument/signatureHelp."
       (let ((entries
              (mapcar
               (jsonrpc-lambda
-                  (&key name kind location _containerName)
+                  (&key name kind location &allow-other-keys)
                 (cons (propertize name :kind (cdr (assoc kind eglot--symbol-kind-names)))
                       (eglot--lsp-position-to-point
                        (plist-get (plist-get location :range) :start))))


### PR DESCRIPTION
Some LSP servers such as [solargraph](https://github.com/castwide/solargraph) may send additional keys in the response to `textDocument/documentSymbol` requests, causing errors such as the following:

```
Keyword argument :deprecated not one of (:name :kind :location :containerName)
```

The corresponding code in solargraph is the following: https://github.com/castwide/solargraph/blob/db06853eff05bb597a40babc78844524bea29139/lib/solargraph/language_server/message/text_document/document_symbol.rb

Thus, the extraneous keys must be ignored.