### PR TITLE
Require subr-x at compile time

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -65,7 +65,8 @@
 (require 'warnings)
 (require 'flymake)
 (require 'xref)
-(require 'subr-x)
+(eval-when-compile
+  (require 'subr-x))
 (require 'jsonrpc)
 (require 'filenotify)
 (require 'ert)


### PR DESCRIPTION
If/when-let are macros that the byte compiler can expand at compile
time. No need to require subr-x at run time.

I've signed the FSF copyright paperwork for Emacs and am OK with that covering this.