### PR TITLE
WIP: pcase macro

### DIFF
--- a/eglot-tests.el
+++ b/eglot-tests.el
@@ -636,6 +636,40 @@ Pass TIMEOUT to `eglot--with-timeout'."
        (eglot--dbind FooObject (&key foo bar) `(:foo "foo" :baz bargh)
          (cons foo bar))))))
 
+(ert-deftest eglot-pcase ()
+  (should
+   (equal nil
+          (let ((eglot-strict-mode nil))
+            (pcase nil
+              ((eglot--object (:foo) () (foo)) foo)))))
+  (should
+   (equal '("foo" . "bar")
+          (let ((eglot-strict-mode nil))
+            (pcase `(:foo "foo" :bar "bar")
+              ((eglot--object (:foo) (:bar) (foo bar)) (cons foo bar))))))
+  (should
+   (equal '("foo" . "bar")
+          (let ((eglot-strict-mode nil))
+            (pcase `(:foo "foo" :bar "bar" :fotrix bargh)
+              ((eglot--object (:foo) (:bar) (foo bar)) (cons foo bar))))))
+  (should
+   (equal nil
+          (let ((eglot-strict-mode '(disallow-non-standard-keys)))
+            (pcase `(:foo "foo" :bar "bar" :fotrix bargh)
+              ((eglot--object (:foo) (:bar) (foo bar)) (cons foo bar))))))
+  (should
+   (equal 'bargh
+          (let ((eglot-strict-mode '(disallow-non-standard-keys)))
+            (pcase `(:foo "foo" :bar "bar" :fotrix bargh)
+              ((eglot--object (:foo) (:bar) (foo bar)) (cons foo bar))
+              ((eglot--object (:fotrix) (:foo :bar) (fotrix)) fotrix)))))
+  (should
+   (equal "bar"
+          (let ((eglot-strict-mode '(disallow-non-standard-keys)))
+            (pcase `(:foo "foo" :bar "bar")
+              ((eglot--object (:foo :other) () (foo)) foo)
+              ((eglot--object (:foo) (:bar) (bar)) bar))))))
+
 (provide 'eglot-tests)
 ;;; eglot-tests.el ends here
 


### PR DESCRIPTION
Previously we were strict about the structure and contents of LSP
objects.  This led to errors when certain servers sent messages with
fields not defined in the specification (because those fields are
used by other clients, or the protocol evolved and added some fields
and we never upgraded).

This commit makes eglot tolerate unknown keys in all incoming
messages.

* eglot.el (eglot--destructuring-bind): New macro.
(eglot-handle-notification):
(eglot--register-unregister):
(eglot--xref-make):
(xref-backend-apropos):
(eglot-completion-at-point):
(eglot--sig-info):
(eglot-help-at-point):
(eglot--apply-workspace-edit):
(eglot-code-actions):
(eglot--register-workspace/didChangeWatchedFiles): Use it instead of
`cl-destructuring-bind`.