### PR TITLE
Fix #164: CodeAction command can be a Command object

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1913,7 +1913,12 @@ If SKIP-SIGNATURE, don't try to send textDocument/signatureHelp."
       (when edit
         (eglot--apply-workspace-edit edit))
       (when command
-        (eglot-execute-command server (intern command) arguments)))))
+        (cond ((stringp command)
+               (eglot-execute-command server (intern command) arguments))
+              ((listp command)
+               (eglot-execute-command server
+                                      (intern (plist-get command :command))
+                                      (plist-get command :arguments))))))))
 
 
 


### PR DESCRIPTION
* eglot.el (eglot-code-actions): Handle case when the :command field
  is not a string.