### PR TITLE
Adjust signature rendering

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1962,13 +1962,10 @@ is not active."
              (goto-char params-start)
              (let ((regex (concat "\\<" (regexp-quote label) "\\>"))
                    (case-fold-search nil))
-               (cl-loop for nmatches from 0
-                        while (re-search-forward regex params-end t)
-                        finally do
-                        (when (= 1 nmatches)
-                          (add-face-text-property
-                           (- (point) (length label)) (point)
-                           'eldoc-highlight-function-argument))))
+               (when (re-search-forward regex params-end t)
+                 (add-face-text-property
+                  (- (point) (length label)) (point)
+                  'eldoc-highlight-function-argument)))
              (when documentation
                (goto-char (point-max))
                (insert "\n"

--- a/eglot.el
+++ b/eglot.el
@@ -1960,10 +1960,10 @@ is not active."
            (eglot--dbind ((ParameterInformation) label documentation)
                (aref parameters active-param)
              (goto-char params-start)
-             (let ((case-fold-search nil))
+             (let ((regex (concat "\\<" (regexp-quote label) "\\>"))
+                   (case-fold-search nil))
                (cl-loop for nmatches from 0
-                        while (and (not (string-empty-p label))
-                                   (search-forward label params-end t))
+                        while (re-search-forward regex params-end t)
                         finally do
                         (when (= 1 nmatches)
                           (add-face-text-property

--- a/eglot.el
+++ b/eglot.el
@@ -1951,7 +1951,7 @@ is not active."
          (setq documentation (match-string 1 documentation))
          (unless (string-prefix-p (string-trim documentation) label)
            (goto-char (point-max))
-           (insert ": " documentation)))
+           (insert ": " (eglot--format-markup documentation))))
        (when (and (eql i active-sig) active-param
                   (< -1 active-param (length parameters)))
          (eglot--dbind ((ParameterInformation) label documentation)


### PR DESCRIPTION
- apply eglot--format-markup to signature documentation
  I think this is intended but missed?

- search for active param only within label
  Previously it searched through both `label` and `documentation` of `sig`. 
  If the function name is found and propertized, begin search after that, so an argument with the same name as the function still works.

- use regex with boundary when searching for active param
  otherwise substrings of the parameter name can be matched. Using `\\<` instead of `\\_<` makes it work with python keyword arguments. 

- just highlight first match (do not require exactly 1 match)
  I found some examples in pyls like completing `[].append(` gives `:label "L.append(object) -> None -- append object to end"` (`append` occurs twice). I think highlighting the first match is ok, but I haven't tested other servers.