### PR TITLE
Add dart_language_server

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ for the language of your choice. Otherwise, it prompts you to enter one:
 * Golang's [go-langserver][go-langserver]
 * Ocaml's [ocaml-language-server][ocaml-language-server]
 * R's [languageserver][r-languageserver]
+* Dart's [dart_language_server][dart_language_server]
 
 I'll add to this list as I test more servers. In the meantime you can
 customize `eglot-server-programs`:
@@ -308,3 +309,4 @@ Under the hood:
 [eclipse-jdt]: https://github.com/eclipse/eclipse.jdt.ls
 [ocaml-language-server]: https://github.com/freebroccolo/ocaml-language-server
 [r-languageserver]: https://cran.r-project.org/package=languageserver
+[dart_language_server]: https://github.com/natebosch/dart_language_server

--- a/eglot.el
+++ b/eglot.el
@@ -100,7 +100,8 @@ language-server/bin/php-language-server.php"))
                                             "-gocodecompletion"))
                                 ((R-mode ess-r-mode) . ("R" "--slave" "-e"
                                                         "languageserver::run()"))
-                                (java-mode . eglot--eclipse-jdt-contact))
+                                (java-mode . eglot--eclipse-jdt-contact)
+                                (dart-mode . ("dart_language_server")))
   "How the command `eglot' guesses the server to start.
 An association list of (MAJOR-MODE . CONTACT) pairs.  MAJOR-MODE
 is a mode symbol, or a list of mode symbols.  The associated


### PR DESCRIPTION
Currently testing with the following snippet.

``` elisp
(defun project-try-dart (dir)
  (let ((project (or (locate-dominating-file dir "pubspec.yaml")
                     (locate-dominating-file dir "BUILD"))))
    (if project
        (cons 'dart project)
      (cons 'transient dir))))
(add-hook 'project-find-functions #'project-try-dart)
(cl-defmethod project-roots ((project (head dart)))
  (list (cdr project)))
```