### PR TITLE
Ensure that the help buffer is not in read only mode.

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1031,6 +1031,7 @@ Doubles as an indicator of snippet support."
                        major-mode))))
     (with-temp-buffer
       (ignore-errors (funcall mode))
+      (read-only-mode -1)
       (insert string) (font-lock-ensure) (buffer-string))))
 
 (defcustom eglot-ignored-server-capabilites (list)


### PR DESCRIPTION
GitHub flavored markdown mode sets the buffer to read-only so further updates will fail.
This change forces the temporary help buffer where the contents are formatted prior to being displayed in the *eglot help* buffer to be writable.
