### PR TITLE
fix errors on add-face-text-property

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2005,9 +2005,10 @@ is not active."
                                    params-end t)
                                   (list (match-beginning 0) (match-end 0))))
                          (mapcar #'1+ (append label nil)))))
-                   (add-face-text-property
-                    beg end
-                    'eldoc-highlight-function-argument)))
+                   (if (and beg end)
+                       (add-face-text-property
+                        beg end
+                        'eldoc-highlight-function-argument))))
                ;; ...and/or maybe add its doc on a line by its own.
                (when documentation
                  (goto-char (point-max))


### PR DESCRIPTION
Hi. Thanks for your cool job.
Function `add-face-text-property` raise errors on every call with nil begin or end parameters.