### PR TITLE
Add support for Dockerfile, HTML, CSS and JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ find-library` can help you tell if that happened.
 * FSharp's [fsharp-mode][fsharp-mode] (Needs to `(require 'eglot-fsharp)` first)
 * YAML's [yaml-language-server][yaml-language-server]
 * Lua's [lua-lsp][lua-lsp]
+* HTML [html_language_server][html_language_server]
+* CSS's [css_language_server][css_language_server]
+* JSON's [json_language_server][json_language_server]
+* Dockerfile's [dockerfile_language_server][dockerfile_language_server]
 
 I'll add to this list as I test more servers. In the meantime you can
 customize `eglot-server-programs`:
@@ -576,6 +580,10 @@ Under the hood:
 [dart_language_server]: https://github.com/natebosch/dart_language_server
 [elixir-ls]: https://github.com/elixir-lsp/elixir-ls
 [erlang_ls]: https://github.com/erlang-ls/erlang_ls
+[html_language_server]: https://github.com/Microsoft/vscode/tree/master/extensions/html-language-features/server
+[css_language_server]: https://github.com/Microsoft/vscode/tree/master/extensions/css-language-features/server
+[json_language_server]: https://www.npmjs.com/package/vscode-json-languageserver
+[dockerfile_language_server]: https://github.com/rcjsuen/dockerfile-language-server-nodejs
 [news]: https://github.com/joaotavora/eglot/blob/master/NEWS.md
 [ada_language_server]: https://github.com/AdaCore/ada_language_server
 [metals]: https://scalameta.org/metals/

--- a/eglot.el
+++ b/eglot.el
@@ -177,7 +177,11 @@ language-server/bin/php-language-server.php"))
                                 (gdscript-mode . ("localhost" 6008))
                                 ((fortran-mode f90-mode) . ("fortls"))
                                 (lua-mode . ("lua-lsp"))
-                                (zig-mode . ("zls")))
+                                (zig-mode . ("zls"))
+                                (css-mode "css-languageserver" "--stdio")
+                                (html-mode "html-languageserver" "--stdio")
+                                (json-mode "json-languageserver" "--stdio")
+                                (dockerfile-mode . ("docker-langserver" "--stdio")))
   "How the command `eglot' guesses the server to start.
 An association list of (MAJOR-MODE . CONTACT) pairs.  MAJOR-MODE
 identifies the buffers that are to be managed by a specific


### PR DESCRIPTION
Support Docker files via https://www.npmjs.com/package/dockerfile-language-server-nodejs

Additionally, you need to install the language server:

$ npm install -g dockerfile-language-server-nodejs 

Edit: Additional servers are installed by:

$ npm install dockerfile-bin-language-server-nodejs vscode-css-languageservice-bin vscode-html-languageservice-bin vscode-json-languageservice-bin