### PR TITLE
Add aliases for xref-find-references, xref-find-definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ configuration according to the value of the variable
 `eglot-workspace-configuration`, which you may be set in a
 `.dir-locals` file, for example.
 
+- `M-x eglot-find-definitions` calls `xref-find-definitions` and
+jumps to the definition of the selected symbol.
+
+- `M-x eglot-find-references` calls `xref-find-references` and
+find references of the selected symbol.
+
 There are *no keybindings* specific to Eglot, but you can bind stuff
 in `eglot-mode-map`, which is active as long as Eglot is managing a
 file in your project. The commands don't need to be Eglot-specific,
@@ -142,7 +148,7 @@ either:
 
 ```
 (define-key eglot-mode-map (kbd "C-c h") 'eglot-help-at-point)
-(define-key eglot-mode-map (kbd "<f6>") 'xref-find-definitions)
+(define-key eglot-mode-map (kbd "<f6>") 'eglot-find-definitions)
 ```
 
 <a name="customization"></a>

--- a/eglot.el
+++ b/eglot.el
@@ -1672,6 +1672,9 @@ Calls REPORT-FN maybe if server publishes diagnostics in time."
 DUMMY is ignored."
   (setq eglot--xref-known-symbols nil))
 
+(defalias 'eglot-find-definitions 'xref-find-definitions)
+(defalias 'eglot-find-references 'xref-find-references)
+
 (advice-add 'xref-find-definitions :after #'eglot--xref-reset-known-symbols)
 (advice-add 'xref-find-references :after #'eglot--xref-reset-known-symbols)
 


### PR DESCRIPTION
When I used this package at the first time, I couldn't find how to execute `Go-to-Definition` and `Find-References` because there were no methods like `eglot-go-to-definitions` or so.

IMO, especially for the newbies like me, eglot should allow them to find easily how to execute such functions after typing `M-x eglot-` (then autocompletion will fire and they can find `eglot-find-definitions` & `eglot-find-references`).