### PR TITLE
Don't activate eglot in invisible buffers

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -761,16 +761,17 @@ INTERACTIVE is t if called interactively."
 ;;;###autoload
 (defun eglot-ensure ()
   "Start Eglot session for current buffer if there isn't one."
-  (let ((buffer (current-buffer)))
-    (cl-labels
-        ((maybe-connect
-          ()
-          (remove-hook 'post-command-hook #'maybe-connect nil)
-          (eglot--with-live-buffer buffer
-            (unless eglot--managed-mode
-              (apply #'eglot--connect (eglot--guess-contact))))))
-      (when buffer-file-name
-        (add-hook 'post-command-hook #'maybe-connect 'append nil)))))
+  (unless (string-match-p "^\s" (buffer-name))
+    (let ((buffer (current-buffer)))
+      (cl-labels
+          ((maybe-connect
+            ()
+            (remove-hook 'post-command-hook #'maybe-connect nil)
+            (eglot--with-live-buffer buffer
+              (unless eglot--managed-mode
+                (apply #'eglot--connect (eglot--guess-contact))))))
+        (when buffer-file-name
+          (add-hook 'post-command-hook #'maybe-connect 'append nil))))))
 
 (defun eglot-events-buffer (server)
   "Display events buffer for SERVER."
@@ -2461,7 +2462,7 @@ potentially rename EGLOT's help buffer."
          (menu `("Eglot code actions:" ("dummy" ,@menu-items)))
          (action (if (listp last-nonmenu-event)
                      (x-popup-menu last-nonmenu-event menu)
-                   (cdr (assoc (completing-read "[eglot] Pick an action: " 
+                   (cdr (assoc (completing-read "[eglot] Pick an action: "
 						menu-items nil t
 						nil nil (car menu-items))
                                menu-items)))))

--- a/eglot.el
+++ b/eglot.el
@@ -2462,7 +2462,7 @@ potentially rename EGLOT's help buffer."
          (menu `("Eglot code actions:" ("dummy" ,@menu-items)))
          (action (if (listp last-nonmenu-event)
                      (x-popup-menu last-nonmenu-event menu)
-                   (cdr (assoc (completing-read "[eglot] Pick an action: "
+                   (cdr (assoc (completing-read "[eglot] Pick an action: " 
 						menu-items nil t
 						nil nil (car menu-items))
                                menu-items)))))

--- a/eglot.el
+++ b/eglot.el
@@ -1229,7 +1229,7 @@ Reset in `eglot--managed-mode-onoff'.")
   "Maybe activate mode function `eglot--managed-mode'.
 If SERVER is supplied, do it only if BUFFER is managed by it.  In
 that case, also signal textDocument/didOpen."
-  (unless eglot--managed-mode
+  (unless (or eglot--managed-mode (string-match-p "^\s" (buffer-name)))
     (unless server
       (when eglot--cached-current-server
         (display-warning


### PR DESCRIPTION
1. To correctly fontify each diff hunk (e.g. on `vc-annotate-show-diff-revision-at-line`) `diff-syntax-fontify-hunk ` creates invisible buffers containing specific file revision and enables major-mode of the file.

2. Eglot sends `didOpen` to server and server sends diagnostics for that specific version of the file.

3. Diagnostic info is displayed in real file buffer. 

It leads to wrong flymake error reports.