### PR TITLE
eglot-completion-at-point: Follow specification more closely

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ ELCFILES := $(ELFILES:.el=.elc)
 ELPADEPS ?=--eval '(package-initialize)'			\
            --eval '(package-refresh-contents)'			\
            --eval '(package-install (quote jsonrpc))'		\
+           --eval '(package-install (quote yasnippet))'		\
            --eval '(package-install 				\
                       (cadr (assoc (quote flymake)		\
                                    package-archive-contents)))'

--- a/eglot-tests.el
+++ b/eglot-tests.el
@@ -524,6 +524,28 @@ pyls prefers autopep over yafp"
                                  (= severity 1))
                                diagnostics)))))))))
 
+(ert-deftest json-basic ()
+  "Test basic autocompletion in vscode-json-languageserver"
+  (skip-unless (executable-find "vscode-json-languageserver"))
+  (eglot--with-fixture
+   '(("project" .
+      (("p.json" . "{\"foo.b")
+       ("s.json" . "{\"properties\":{\"foo.bar\":{\"default\":\"fb\"}}}")
+       (".git" . nil))))
+   (with-current-buffer
+       (eglot--find-file-noselect "project/p.json")
+     (yas-minor-mode)
+     (goto-char 2)
+     (insert "\"$schema\": \"file://"
+             (file-name-directory buffer-file-name) "s.json\",")
+     (let ((eglot-server-programs
+            '((js-mode . ("vscode-json-languageserver" "--stdio")))))
+       (goto-char (point-max))
+       (should (eglot--tests-connect))
+       (completion-at-point)
+       (should (looking-back "\"foo.bar\": \""))
+       (should (looking-at "fb\"$"))))))
+
 (ert-deftest eglot-ensure ()
   "Test basic `eglot-ensure' functionality"
   (skip-unless (executable-find "pyls"))


### PR DESCRIPTION
This is a WIP.

It seems eglot assumed that the triggerChacters couldn't be inside the
completion bounds.  This assumption does not hold with the
vscode-json-languageserver.  So the patched version of
eglot-completion-at-point asks the server for possible completions and
calculates the bounds from them (if the completions are consistent in
this regard.)

Additionally, vscode-json-languageserver returns completions with
different filterText and label fields.  The LSP specification is
usually quite vague, but not this time:

    filterText: A string that should be used when filtering a set of
    completion items. When `falsy` the label is used.

Although it never defines what it means by filtering.  Anyway, the new
test `json-basic` succeeds when the patch is applied, and fails
otherwise.  It assumes the server installed as root, e.g.:

    sudo npm install -g vscode-json-languageserver

Unfortunately, the code needs polishing.  eglot calls
textDocument/completion twice at the beginning of a completion.  But I
don't understand why it is necessary to fetch the completions from the
server more than once, so I haven't modified this part of the code.

I haven't run the rust and the eclipse tests, but hopefully those are
unaffected by this change.

Feedback on how to proceed is obviously welcome.  Thanks.