### PR TITLE
More customizable eclipse jdt configuration

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2422,6 +2422,14 @@ If SKIP-SIGNATURE, don't try to send textDocument/signatureHelp."
 
 ;;; eclipse-jdt-specific
 ;;;
+(defcustom eglot-eclipse-jdt-config-dir nil
+  "Path of eclipse jdt configuration files."
+  :type 'string)
+
+(defcustom eglot-eclipse-jdt-java-home nil
+  "Java version to be used for starting eclipse jdt ls."
+  :type 'string)
+
 (defclass eglot-eclipse-jdt (eglot-lsp-server) ()
   :documentation "Eclipse's Java Development Tools Language Server.")
 
@@ -2480,7 +2488,7 @@ If INTERACTIVE, prompt user for details."
            (repodir (if (file-directory-p repodir) repodir dir))
            (config
             (concat
-             repodir
+             (or (if eglot-eclipse-jdt-config-dir (expand-file-name eglot-eclipse-jdt-config-dir)) repodir)
              (cond
               ((string= system-type "darwin") "config_mac")
               ((string= system-type "windows-nt") "config_win")
@@ -2503,7 +2511,7 @@ If INTERACTIVE, prompt user for details."
       (unless (file-directory-p workspace)
         (make-directory workspace t))
       (cons 'eglot-eclipse-jdt
-            (list (executable-find "java")
+            (list (if eglot-eclipse-jdt-java-home (concat (expand-file-name eglot-eclipse-jdt-java-home) "/bin/java") (executable-find "java"))
                   "-Declipse.application=org.eclipse.jdt.ls.core.id1"
                   "-Dosgi.bundles.defaultStartLevel=4"
                   "-Declipse.product=org.eclipse.jdt.ls.core.product"


### PR DESCRIPTION
Some changes to make Eclipse Jdt configuration more customizable. Particularly two variables to specify configuration directory and java home to be used to start Eclipse Jdt LS. I think they could be useful for example, in case of system installation of Eclipse JDT LS, which is my case of course.

Let me know.