### PR TITLE
Fix handle-event calls for 'renamed

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2367,8 +2367,8 @@ If SKIP-SIGNATURE, don't try to send textDocument/signatureHelp."
                                                    (changed 2)
                                                    (deleted 3)))))))
              ((eq action 'renamed)
-              (handle-event desc 'deleted file)
-              (handle-event desc 'created file1))))))
+              (handle-event '(desc 'deleted file))
+              (handle-event '(desc 'created file1)))))))
       (unwind-protect
           (progn (dolist (dir (delete-dups (mapcar #'file-name-directory globs)))
                    (push (file-notify-add-watch dir '(change) #'handle-event)


### PR DESCRIPTION
Fixes two function calls that had the wrong type of arguments resulting in `(wrong-number-of-arguments (1 . 1) 3)` when renaming files in a directory watched by eglot.