### PR TITLE
Use gfm-view-mode or text-mode to format markup

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1055,7 +1055,10 @@ Doubles as an indicator of snippet support."
                (if (stringp markup) (list (string-trim markup)
                                           (intern "gfm-view-mode"))
                  (list (plist-get markup :value)
-                       major-mode))))
+                       (intern
+                        (if (equal (plist-get markup :kind) "markdown")
+                            "gfm-view-mode"
+                          "text-mode"))))))
     (with-temp-buffer
       (insert string)
       (ignore-errors (funcall mode)) (font-lock-ensure) (buffer-string))))


### PR DESCRIPTION
Temporary buffer that used to format markup must be in `gfm-view-mode` or `text-mode` according to `kind` of `MarkupContent` and not in current major mode.