### PR TITLE
Handle offsets as label on printing parameter docs

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2042,8 +2042,10 @@ is not active."
                (when documentation
                  (goto-char (point-max))
                  (insert "\n"
-                         (propertize
-                          label 'face 'eldoc-highlight-function-argument)
+                         (if (stringp label)
+                             (propertize
+                              label 'face 'eldoc-highlight-function-argument)
+                           (apply #'buffer-substring (mapcar #'1+ label)))
                          ": " (eglot--format-markup documentation))))))
          (buffer-string))))
    when moresigs concat "\n"))


### PR DESCRIPTION
Buffer substring with active parameter is already propertized with `eldoc-highlight-function-argument` face