### PR TITLE
Ignore extra diagnostic args that flymake does not support

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1331,7 +1331,9 @@ Uses THING, FACE, DEFS and PREPEND."
 (put 'eglot-warning 'flymake-category 'flymake-warning)
 (put 'eglot-error 'flymake-category 'flymake-error)
 
-(defalias 'eglot--make-diag 'flymake-make-diagnostic)
+(defun eglot--make-diag (buffer beg end type text &optional desc file1)
+  (flymake-make-diagnostic buffer beg end type text))
+
 (defalias 'eglot--diag-data 'flymake-diagnostic-data)
 
 (cl-loop for i from 1


### PR DESCRIPTION
Firing up eglot with `hie-wrapper` 0.9.0.0 causes errors, apparently due to additional args being passed to the diagnostic callback. That callback is an alias for flycheck's diagnostic function, which only supports specific args, and this fix (or something like it) appears therefore to be required to avoid breakage.