### PR TITLE
Fix invalid guess for php language Server (#288)

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -84,14 +84,14 @@
                                   typescript-mode)
                                  . ("javascript-typescript-stdio"))
                                 (sh-mode . ("bash-language-server" "start"))
+				(php-mode . ("php" "vendor/felixfbecker/\
+language-server/bin/php-language-server.php"))
                                 ((c++-mode c-mode) . ("ccls"))
                                 ((caml-mode tuareg-mode reason-mode)
                                  . ("ocaml-language-server" "--stdio"))
                                 (ruby-mode
                                  . ("solargraph" "socket" "--port"
                                     :autoport))
-                                (php-mode . ("php" "vendor/felixfbecker/\
-language-server/bin/php-language-server.php"))
                                 (haskell-mode . ("hie-wrapper"))
                                 (kotlin-mode . ("kotlin-language-server"))
                                 (go-mode . ("go-langserver" "-mode=stdio"


### PR DESCRIPTION
* eglot.el (eglot-server-programs): Change the position of the php
language server, otherwise it will always be hidden by the c-mode
server (php-mode is derived from c-mode).