### PR TITLE
Require array package to use current-line

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -70,6 +70,7 @@
 (require 'jsonrpc)
 (require 'filenotify)
 (require 'ert)
+(require 'array)
 
 
 ;;; User tweakable stuff


### PR DESCRIPTION
The jsonrpc package (one of eglot's dependencies) recently updated and removed
the line requiring the array package. The `current-line' function is provided by
array and is used by eglot, so let's require array explicitly. Here's jsonrpc's
guilty commit:

https://git.savannah.gnu.org/cgit/emacs.git/commit/lisp/jsonrpc.el?id=c676444a43e4634c1f98ec286b5bd9e46b23216b