### PR TITLE
Fix #268: Add flymake-diagnostic-function as a local hook

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1172,7 +1172,7 @@ and just return it.  PROMPT shouldn't end with a question mark."
     (add-hook 'post-self-insert-hook 'eglot--post-self-insert-hook nil t)
     (add-hook 'pre-command-hook 'eglot--pre-command-hook nil t)
     (eglot--setq-saving eldoc-documentation-function #'eglot-eldoc-function)
-    (eglot--setq-saving flymake-diagnostic-functions '(eglot-flymake-backend t))
+    (add-hook 'flymake-diagnostic-functions #'eglot-flymake-backend nil t)
     (add-function :around (local 'imenu-create-index-function) #'eglot-imenu)
     (flymake-mode 1)
     (eldoc-mode 1))


### PR DESCRIPTION
I noticed other packages, e.g. `package-lint` used the local hooks to add `flymake-diagnostic-functions` as well as eglot using it for `xref-backend-functions` so I was curious to try it out.

This solved this issue for me, I noticed there was already a remove-hook call further down when unloading eglot as well.

If this is the needed change, feel free to merge, otherwise feel free to close/ignore it.

Thank you.