### PR TITLE
Treat null/nil server capabilities as false

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1101,6 +1101,9 @@ under cursor."
              for probe = (plist-member caps feat)
              if (not probe) do (cl-return nil)
              if (eq (cadr probe) :json-false) do (cl-return nil)
+             ;; If the server specifies null as the value of the capability, it
+             ;; makes sense to treat it like false.
+             if (null (cadr probe)) do (cl-return nil)
              if (not (listp (cadr probe))) do (cl-return (if more nil (cadr probe)))
              finally (cl-return (or (cadr probe) t)))))
 


### PR DESCRIPTION
Some language servers (the PHP one for example) may specify null for
some capabilities in the list of server capabilities. This does not
conform to the specification, but treating it as false is more
reasonable than treating it as true.