### PR TITLE
Change Go LS default to gopls

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ for the language you're using. Otherwise, it prompts you to enter one.
 * C/C++'s [ccls][ccls]  ([cquery][cquery] and [clangd][clangd] also work)
 * Haskell's [IDE engine][haskell-ide-engine]
 * Kotlin's [kotlin-language-server][kotlin-language-server]
-* Golang's [go-langserver][go-langserver]
+* Go's [gopls][gopls]
 * Ocaml's [ocaml-language-server][ocaml-language-server]
 * R's [languageserver][r-languageserver]
 * Dart's [dart_language_server][dart_language_server]
@@ -348,7 +348,7 @@ Under the hood:
 [windows-subprocess-hang]: https://www.gnu.org/software/emacs/manual/html_node/efaq-w32/Subprocess-hang.html
 [haskell-ide-engine]: https://github.com/haskell/haskell-ide-engine
 [kotlin-language-server]: https://github.com/fwcd/KotlinLanguageServer
-[go-langserver]: https://github.com/sourcegraph/go-langserver
+[gopls]: https://github.com/golang/go/wiki/gopls
 [eclipse-jdt]: https://github.com/eclipse/eclipse.jdt.ls
 [ocaml-language-server]: https://github.com/freebroccolo/ocaml-language-server
 [r-languageserver]: https://cran.r-project.org/package=languageserver

--- a/eglot.el
+++ b/eglot.el
@@ -95,8 +95,7 @@ language-server/bin/php-language-server.php"))
                                     :autoport))
                                 (haskell-mode . ("hie-wrapper"))
                                 (kotlin-mode . ("kotlin-language-server"))
-                                (go-mode . ("go-langserver" "-mode=stdio"
-                                            "-gocodecompletion"))
+                                (go-mode . ("gopls"))
                                 ((R-mode ess-r-mode) . ("R" "--slave" "-e"
                                                         "languageserver::run()"))
                                 (java-mode . eglot--eclipse-jdt-contact)


### PR DESCRIPTION
github.com/sourcegraph/go-langserver has been put on the backburner, and
the maintainers themselves advocate using Google's gopls instead.  gopls
is actively developed and, although still labeled "alpha", already works
very nicely.


----

#