### PR TITLE
Fix sending __dummy__ as parameter in "initialized" notification

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -844,7 +844,7 @@ This docstring appeases checkdoc, that's all."
                           (push server
                                 (gethash project eglot--servers-by-project))
                           (setf (eglot--capabilities server) capabilities)
-                          (jsonrpc-notify server :initialized `(:__dummy__ t))
+                          (jsonrpc-notify server :initialized (make-hash-table))
                           (dolist (buffer (buffer-list))
                             (with-current-buffer buffer
                               (eglot--maybe-activate-editing-mode server)))


### PR DESCRIPTION
```
Eglot uses a parameter named __dummy__ with value t for a placeholder
instead of an empty argument list. However, this causes the parameter
to be actually sent to the server.

The JSON-RPC specification states "The names MUST match exactly,
including case, to the method's expected parameters"; so, this
behavior seems to be non-conforming according to JSON-RPC.

The LSP specification does not seem to indicate how servers should
handle method calls with parameters they do not support.  As such,
ignoring the parameter, or reporting an error, or crashing all seem to
be "valid" behaviors as far as the specification is concerned.

We can avoid this by using an empty hash table instead of a dummy
parameter.  (As far as I can see, an empty hash table is the only
Emacs Lisp object which serializes to an empty JSON object in
jsonrpc--json-encode.)
```