### PR TITLE
Tailor completions items to the backend if necessary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ ELCFILES := $(ELFILES:.el=.elc)
 ELPADEPS ?=--eval '(package-initialize)'			\
            --eval '(package-refresh-contents)'			\
            --eval '(package-install (quote jsonrpc))'		\
+           --eval '(package-install (quote yasnippet))'		\
            --eval '(package-install 				\
                       (cadr (assoc (quote flymake)		\
                                    package-archive-contents)))'

--- a/eglot-tests.el
+++ b/eglot-tests.el
@@ -432,6 +432,20 @@ Pass TIMEOUT to `eglot--with-timeout'."
       (completion-at-point)
       (should (looking-back "sys.exit")))))
 
+(ert-deftest snippet-completions ()
+  "Test simple snippet completion in a python LSP"
+  (skip-unless (and (executable-find "pyls")
+                    (functionp 'yas-minor-mode)))
+  (eglot--with-fixture
+      '(("project" . (("something.py" . "setatt"))))
+    (with-current-buffer
+        (eglot--find-file-noselect "project/something.py")
+      (yas-minor-mode 1)
+      (should (eglot--tests-connect))
+      (goto-char (point-max))
+      (completion-at-point)
+      (should (looking-back "setattr(")))))
+
 (ert-deftest hover-after-completions ()
   "Test documentation echo in a python LSP"
   (skip-unless (executable-find "pyls"))


### PR DESCRIPTION
I'd appreciate any feedback because my programming style here might be questionable. 

---

The :exit-function of the completion command doesn't get called under
special circumstances.  Fix this by altering the completion candidate.

Closes #311.

* eglot.el (eglot--tailor-completions): New function.
(eglot-completion-at-point): Use it.