### PR TITLE
Ada Language Server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ for the language you're using. Otherwise, it prompts you to enter one.
 * R's [languageserver][r-languageserver]
 * Dart's [dart_language_server][dart_language_server]
 * Elixir's [elixir-ls][elixir-ls]
+* Ada's [ada_language_server][ada_language_server]
 
 I'll add to this list as I test more servers. In the meantime you can
 customize `eglot-server-programs`:
@@ -394,3 +395,4 @@ Under the hood:
 [dart_language_server]: https://github.com/natebosch/dart_language_server
 [elixir-ls]: https://github.com/JakeBecker/elixir-ls
 [news]: https://github.com/joaotavora/eglot/blob/master/NEWS.md
+[ada_language_server]: https://github.com/AdaCore/ada_language_server

--- a/eglot.el
+++ b/eglot.el
@@ -100,7 +100,8 @@ language-server/bin/php-language-server.php"))
                                                         "languageserver::run()"))
                                 (java-mode . eglot--eclipse-jdt-contact)
                                 (dart-mode . ("dart_language_server"))
-                                (elixir-mode . ("language_server.sh")))
+                                (elixir-mode . ("language_server.sh"))
+                                (ada-mode . ("ada_language_server")))
   "How the command `eglot' guesses the server to start.
 An association list of (MAJOR-MODE . CONTACT) pairs.  MAJOR-MODE
 is a mode symbol, or a list of mode symbols.  The associated


### PR DESCRIPTION
Add support for the Ada Language Server.
Closes #316.

* eglot.el (eglot-server-programs): Add ada-mode entry.
* README.md (Connecting to a server): Add Ada entry.