### PR TITLE
Add a simple github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,12 @@
+---
+name: Bug report
+about: Create a report to help us improve Eglot
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Before submitting an issue, please, read our guidelines
+on reporting bugs here:
+https://github.com/joaotavora/eglot#reporting-bugs


### PR DESCRIPTION
Background info: https://help.github.com/en/articles/about-issue-and-pull-request-templates

Hopefully, this template leads towards fewer back-and-forth
communication, detailed bug reports, and easier maintainership.

* .github/ISSUE_TEMPLATE/bug_report.md: New file.