### PR TITLE
Don't run mode hooks in eglot--format-markup

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1083,7 +1083,9 @@ Doubles as an indicator of snippet support."
                        major-mode))))
     (with-temp-buffer
       (insert string)
-      (ignore-errors (funcall mode)) (font-lock-ensure) (buffer-string))))
+      (ignore-errors (delay-mode-hooks (funcall mode)))
+      (font-lock-ensure)
+      (buffer-string))))
 
 (defcustom eglot-ignored-server-capabilites (list)
   "LSP server capabilities that Eglot could use, but won't.


### PR DESCRIPTION
Since we want only the syntax highlight provided by the major mode, it makes sense to ignore user's customization functions on the major mode's hook.