### PR TITLE
Support markdown for hover

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -489,7 +489,8 @@ treated as in `eglot-dbind'."
                                            t
                                          :json-false))
                                     :contextSupport t)
-             :hover              `(:dynamicRegistration :json-false)
+             :hover              (list :dynamicRegistration :json-false
+                                       :contentFormat ["markdown" "plaintext"])
              :signatureHelp      (list :dynamicRegistration :json-false
                                        :signatureInformation
                                        `(:parameterInformation
@@ -1080,7 +1081,9 @@ Doubles as an indicator of snippet support."
                (if (stringp markup) (list (string-trim markup)
                                           (intern "gfm-view-mode"))
                  (list (plist-get markup :value)
-                       major-mode))))
+                       (pcase (plist-get markup :kind)
+                         ("markdown" 'gfm-view-mode)
+                         (_ major-mode))))))
     (with-temp-buffer
       (insert string)
       (ignore-errors (delay-mode-hooks (funcall mode)))


### PR DESCRIPTION
For #328 

There are still two issues about the hover/eldoc:

1. Eglot adds the function name at the beginning, it seems not necessary, at least with Gopls
2. `gfm-view-mode` outputs an empty line at the end
 
![image](https://user-images.githubusercontent.com/4550353/67668016-16930080-f9aa-11e9-82e7-ed0df08f7954.png)

you can reproduce the issue of `gfm-view-mode` with this, it seems if there is a code block at the end of the markdown source, `gfm-view-mode` will add an empty line.
 
```el
(message
 "%s"
 (with-temp-buffer
   (insert
    "Errorf formats according to a format specifier and returns the string as a value that satisfies error\\.\n```go\nfunc fmt.Errorf(format string, a ...interface{}) error\n```\n")
   (gfm-view-mode)
   (font-lock-ensure)
   (buffer-string)))
```
