### PR TITLE
Fix resetting eglot--cached-current-server on shutdown

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -610,6 +610,7 @@ SERVER.  ."
   (setf (gethash (eglot--project server) eglot--servers-by-project)
         (delq server
               (gethash (eglot--project server) eglot--servers-by-project)))
+  (setq eglot--cached-current-server nil)
   (cond ((eglot--shutdown-requested server)
          t)
         ((not (eglot--inhibit-autoreconnect server))


### PR DESCRIPTION
The aggressive caching introduced in #338 made it possible for a server that no longer existed to still be cached.