### PR TITLE
Support serverInfo of LSP 3.15.0

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -229,7 +229,7 @@ let the buffer grow forever."
       (DocumentHighlight (:range) (:kind))
       (FileSystemWatcher (:globPattern) (:kind))
       (Hover (:contents) (:range))
-      (InitializeResult (:capabilities))
+      (InitializeResult (:capabilities :serverInfo))
       (Location (:uri :range))
       (LogMessageParams (:type :message))
       (MarkupContent (:kind :value))
@@ -531,6 +531,9 @@ treated as in `eglot-dbind'."
    (capabilities
     :documentation "JSON object containing server capabilities."
     :accessor eglot--capabilities)
+   (server-info
+    :documentation "JSON object containing server info."
+    :accessor eglot--server-info)
    (shutdown-requested
     :documentation "Flag set when server is shutting down."
     :accessor eglot--shutdown-requested)
@@ -856,11 +859,12 @@ This docstring appeases checkdoc, that's all."
                                                     server)
                             :capabilities (eglot-client-capabilities server))
                       :success-fn
-                      (eglot--lambda ((InitializeResult) capabilities)
+                      (eglot--lambda ((InitializeResult) capabilities serverInfo)
                         (unless cancelled
                           (push server
                                 (gethash project eglot--servers-by-project))
                           (setf (eglot--capabilities server) capabilities)
+                          (setf (eglot--server-info server) serverInfo)
                           (jsonrpc-notify server :initialized (make-hash-table))
                           (dolist (buffer (buffer-list))
                             (with-current-buffer buffer
@@ -883,7 +887,9 @@ This docstring appeases checkdoc, that's all."
                           (eglot--message
                            "Connected! Server `%s' now managing `%s' buffers \
 in project `%s'."
-                           (jsonrpc-name server) managed-major-mode
+
+                           (or (plist-get serverInfo :name) readable-name)
+                           managed-major-mode
                            (eglot--project-nickname server))
                           (when tag (throw tag t))))
                       :timeout eglot-connect-timeout


### PR DESCRIPTION
Add support for serverInfo from the upcoming specification.  This
changeset just stores the info sent by the server and slightly changes
a greeting message.  But it opens up the possibility to identify
servers even when eglot uses a TCP connection and therefore makes
possible to implement server specific features (in eglot-x).

Old message:
```
Connected! Server `EGLOT (test-ccls/c++-mode)' now managing `c++-mode' buffers in project `test-ccls'.
```

New message:
```
Connected! Server `ccls' now managing `c++-mode' buffers in project `test-ccls'.
```

* eglot.el (eglot--lsp-interface-alist):  Extend it with serverInfo.
(eglot-lsp-server): Add member variable server-info.
(eglot--connect): Store server-info and display server's name
when connected.