### PR TITLE
Fix #339: fail when eglot-find-* find no references

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1870,7 +1870,9 @@ Try to visit the target file for a richer summary line."
                                method
                                :extra-params extra-params
                                :capability capability)))
-    (xref-find-references "LSP identifier at point.")))
+    (if eglot--lsp-xref-refs
+        (xref-find-references "LSP identifier at point.")
+      (eglot--message "%s returned no references" method))))
 
 (defun eglot-find-declaration ()
   "Find declaration for SYM, the identifier at point."


### PR DESCRIPTION
I'm still not sure whether this issue bothers others as well, but the behavior gets more annoying with non-standard ccls reference methods.  For example, when I request $ccls/navigate and see the result of :textDocument/references.

* eglot.el (eglot--lsp-xref-helper): Display message when no
references have been found instead of calling xref-find-references.