### PR TITLE
Remove the display of (snippet) in completion annotation

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2035,10 +2035,7 @@ is not active."
              (when annotation
                (concat " "
                        (propertize annotation
-                                   'face 'font-lock-function-name-face)
-                       (and (eql insertTextFormat 2)
-                            (eglot--snippet-expansion-fn)
-                            " (snippet)"))))))
+                                   'face 'font-lock-function-name-face))))))
        :company-doc-buffer
        (lambda (proxy)
          (let* ((documentation


### PR DESCRIPTION
I'm using Eglot with Gopls. During code completion, `(snippet)` shows all the time, even I'm completing a variable such as `os.O_RDONLY`, I'm not sure it's a bug of Eglot. Anyway it is not useful for me and takes some valuable space, so I want it to be stripped.

![Screen Shot 2019-11-16 at 20 16 47](https://user-images.githubusercontent.com/4550353/68993047-4731d000-08ae-11ea-977f-1b2a776f3f69.png)
