### PR TITLE
Make some private variables/functions public (fix #354)

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -565,6 +565,11 @@ treated as in `eglot-dbind'."
   "Represents a server. Wraps a process for LSP communication.")
 
 
+(cl-defmethod eglot-server-name (server)
+  "Return a friendly name describing the server."
+  (or (plist-get (eglot--server-info server) :name)
+      (jsonrpc-name server)))
+
 ;;; Process management
 (defvar eglot--servers-by-project (make-hash-table :test #'equal)
   "Keys are projects.  Values are lists of processes.")
@@ -902,8 +907,7 @@ This docstring appeases checkdoc, that's all."
                           (eglot--message
                            "Connected! Server `%s' now managing `%s' buffers \
 in project `%s'."
-                           (or (plist-get serverInfo :name)
-                               (jsonrpc-name server))
+                           (eglot-server-name server)
                            managed-major-mode
                            (eglot-project-nickname server))
                           (when tag (throw tag t))))
@@ -2565,6 +2569,11 @@ If SKIP-SIGNATURE, don't try to send textDocument/signatureHelp."
   "Handle notification window/progress"
   (setf (eglot--spinner server) (list id title done message)))
 
+(cl-defmethod eglot-server-name ((server eglot-rls))
+  "Return a friendly name describing the server."
+  (or (plist-get (eglot--server-info server) :name)
+      "rls"))
+
 
 ;;; eclipse-jdt-specific
 ;;;
@@ -2661,6 +2670,11 @@ If INTERACTIVE, prompt user for details."
   ((_server eglot-eclipse-jdt) (_cmd (eql java.apply.workspaceEdit)) arguments)
   "Eclipse JDT breaks spec and replies with edits as arguments."
   (mapc #'eglot--apply-workspace-edit arguments))
+
+(cl-defmethod eglot-server-name ((server eglot-eclipse-jdt))
+  "Return a friendly name describing the server."
+  (or (plist-get (eglot--server-info server) :name)
+      "eclipse-jdt"))
 
 (provide 'eglot)
 ;;; eglot.el ends here

--- a/eglot.el
+++ b/eglot.el
@@ -525,7 +525,8 @@ treated as in `eglot-dbind'."
 (defclass eglot-lsp-server (jsonrpc-process-connection)
   ((project-nickname
     :documentation "Short nickname for the associated project."
-    :accessor eglot--project-nickname)
+    :accessor eglot--project-nickname
+    :reader eglot-project-nickname)
    (major-mode
     :documentation "Major mode symbol."
     :accessor eglot--major-mode)
@@ -904,7 +905,7 @@ in project `%s'."
                            (or (plist-get serverInfo :name)
                                (jsonrpc-name server))
                            managed-major-mode
-                           (eglot--project-nickname server))
+                           (eglot-project-nickname server))
                           (when tag (throw tag t))))
                       :timeout eglot-connect-timeout
                       :error-fn (eglot--lambda ((ResponseError) code message)
@@ -1170,7 +1171,7 @@ and just return it.  PROMPT shouldn't end with a question mark."
                           being hash-values of eglot--servers-by-project
                           append servers))
         (name (lambda (srv)
-                (format "%s/%s" (eglot--project-nickname srv)
+                (format "%s/%s" (eglot-project-nickname srv)
                         (eglot--major-mode srv)))))
     (cond ((null servers)
            (eglot--error "No servers!"))
@@ -1374,7 +1375,7 @@ Uses THING, FACE, DEFS and PREPEND."
 (defun eglot--mode-line-format ()
   "Compose the EGLOT's mode-line."
   (pcase-let* ((server (eglot-current-server))
-               (nick (and server (eglot--project-nickname server)))
+               (nick (and server (eglot-project-nickname server)))
                (pending (and server (hash-table-count
                                      (jsonrpc--request-continuations server))))
                (`(,_id ,doing ,done-p ,_detail) (and server (eglot--spinner server)))


### PR DESCRIPTION
This PR creates public versions of the these private functions/variables: eglot--managed-mode-hook, eglot--project-nickname, eglot--server-info.  Each one required different approach, and I'm not confident in any of them.  So feedback is welcome.