### PR TITLE
Add metals as the language server for Scala

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ for the language you're using. Otherwise, it prompts you to enter one.
 * Dart's [dart_language_server][dart_language_server]
 * Elixir's [elixir-ls][elixir-ls]
 * Ada's [ada_language_server][ada_language_server]
+* Scala's [metals][metals]
 
 I'll add to this list as I test more servers. In the meantime you can
 customize `eglot-server-programs`:
@@ -455,3 +456,4 @@ Under the hood:
 [elixir-ls]: https://github.com/JakeBecker/elixir-ls
 [news]: https://github.com/joaotavora/eglot/blob/master/NEWS.md
 [ada_language_server]: https://github.com/AdaCore/ada_language_server
+[metals]: http://scalameta.org/metals/

--- a/eglot.el
+++ b/eglot.el
@@ -104,7 +104,8 @@ language-server/bin/php-language-server.php"))
                                 (java-mode . eglot--eclipse-jdt-contact)
                                 (dart-mode . ("dart_language_server"))
                                 (elixir-mode . ("language_server.sh"))
-                                (ada-mode . ("ada_language_server")))
+                                (ada-mode . ("ada_language_server"))
+                                (scala-mode . ("metals-emacs")))
   "How the command `eglot' guesses the server to start.
 An association list of (MAJOR-MODE . CONTACT) pairs.  MAJOR-MODE
 is a mode symbol, or a list of mode symbols.  The associated


### PR DESCRIPTION
* README.md (Connecting to a server): Add metals to the list
* eglot.el (eglot-server-programs): Add metals for scala-mode