### PR TITLE
Eglot confirm edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,9 @@ documentation on what these do.
 - `eglot-auto-display-help-buffer`: If non-nil, automatically display
   `*eglot-help*` buffer;
 
+- `eglot-confirm-server-initiated-edits`: If non-nil, ask for confirmation before
+  editing;
+
 There are a couple more variables that you can customize via Emacs
 lisp:
 

--- a/README.md
+++ b/README.md
@@ -273,8 +273,8 @@ documentation on what these do.
 - `eglot-auto-display-help-buffer`: If non-nil, automatically display
   `*eglot-help*` buffer;
 
-- `eglot-confirm-server-initiated-edits`: If non-nil, ask for confirmation before
-  editing;
+- `eglot-confirm-server-initiated-edits`: If non-nil, ask for confirmation 
+  before allowing server to edit the source buffer's text;
 
 There are a couple more variables that you can customize via Emacs
 lisp:

--- a/eglot.el
+++ b/eglot.el
@@ -193,6 +193,11 @@ let the buffer grow forever."
   :type '(choice (const :tag "No limit" nil)
                  (integer :tag "Number of characters")))
 
+(defcustom eglot-confirm-server-initiated-edits 'confirm
+  "Non-nil if server-initiated edits should be confirmed with user."
+  :type '(choice (const :tag "Don't show confirmation prompt" nil)
+                 (symbol :tag "Show confirmation prompt" 'confirm)))
+
 
 ;;; Constants
 ;;;
@@ -1547,7 +1552,7 @@ THINGS are either registrations or unregisterations (sic)."
 (cl-defmethod eglot-handle-request
   (_server (_method (eql workspace/applyEdit)) &key _label edit)
   "Handle server request workspace/applyEdit"
-  (eglot--apply-workspace-edit edit 'confirm))
+  (eglot--apply-workspace-edit edit eglot-confirm-server-initiated-edits))
 
 (defun eglot--TextDocumentIdentifier ()
   "Compute TextDocumentIdentifier object for current buffer."


### PR DESCRIPTION
This  PR adds a new defcustom for eglot. When editing using code actions, I want to be able to skip confirmation, since always pressing 'y' gets tedious over time. 

I made sure not to change default behaviour, so this is an opt-in feature. 