### PR TITLE
Add error handling for empty thing-at-point

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2419,7 +2419,9 @@ If SKIP-SIGNATURE, don't try to send textDocument/signatureHelp."
 (defun eglot-rename (newname)
   "Rename the current symbol to NEWNAME."
   (interactive
-   (list (read-from-minibuffer (format "Rename `%s' to: " (symbol-at-point)))))
+   (list (read-from-minibuffer
+          (format "Rename `%s' to: " (or (thing-at-point 'symbol t)
+                                         "unknown symbol")))))
   (unless (eglot--server-capable :renameProvider)
     (eglot--error "Server can't rename!"))
   (eglot--apply-workspace-edit


### PR DESCRIPTION
This PR fixes a bug(possibly?) where eglot-rename used on blank space would allow for edit, and report as a successful edit. Mostly a UX fix, since previous version wasn't destructive. 

A little unsure about removing the use of interactive, but I couldn't find a way to error early without removing it

This is a suggestion PR, but I believe it adds some value 