### PR TITLE
Remove never mind from prompt.

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ documentation on what these do.
 - `eglot-auto-display-help-buffer`: If non-nil, automatically display
   `*eglot-help*` buffer;
 
-- `eglot-confirm-server-initiated-edits`: If non-nil, ask for confirmation 
+- `eglot-confirm-server-initiated-actions`: If non-nil, ask for confirmation
   before allowing server to edit the source buffer's text;
 
 There are a couple more variables that you can customize via Emacs


### PR DESCRIPTION
This PR removes the never mind option in tmm when using code action. The prompt already clearly states that C-g or ESC ESC ESC is enough to cancel, so I think never mind option only adds noise.

Yet again mostly a suggestion fix :)