### PR TITLE
* eglot.el (eglot-eldoc-function): Fix outdated docstring.

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2254,8 +2254,7 @@ potentially rename EGLOT's help buffer."
     (eldoc-message string)))
 
 (defun eglot-eldoc-function ()
-  "EGLOT's `eldoc-documentation-function' function.
-If SKIP-SIGNATURE, don't try to send textDocument/signatureHelp."
+  "EGLOT's `eldoc-documentation-function' function."
   (let* ((buffer (current-buffer))
          (server (eglot--current-server-or-lose))
          (position-params (eglot--TextDocumentPositionParams))


### PR DESCRIPTION
This PR removes `SKIP-SIGNATURE` from the docstring - the `eglot-eldoc-function` function doesn't take such a parameter

I've signed the FSF agreement.