### PR TITLE
Fix #389: Avoid autoshutdown on dead servers.

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1289,7 +1289,7 @@ For example, to keep your Company customization use
         (setf (eglot--managed-buffers server)
               (delq (current-buffer) (eglot--managed-buffers server)))
         (when (and eglot-autoshutdown
-                   (not (eglot--shutdown-requested server))
+                   (jsonrpc-running-p server)
                    (not (eglot--managed-buffers server)))
           (eglot-shutdown server)))))))
 


### PR DESCRIPTION
Autoshutdown behavior is only useful if the server is still alive.
The previous check against --shutdown-requested was equivalent when
the user manually requested a shutdown but would lose on unexpected
server process death.

* eglot.el (eglot--managed-mode): Check server running-p.