### PR TITLE
Scratch/fix 354 v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,9 @@ lisp:
 - `eglot-server-initialized-hook`: Hook run after server is
   successfully initialized;
 
+- `eglot-managed-mode-hook`: Hook run after Eglot starts/stops
+  managing a buffer.  See its documentation for usage tips;
+
 # How does Eglot work?
 
 `M-x eglot` starts a server via a shell-command guessed from

--- a/eglot.el
+++ b/eglot.el
@@ -534,7 +534,8 @@ treated as in `eglot-dbind'."
 (defclass eglot-lsp-server (jsonrpc-process-connection)
   ((project-nickname
     :documentation "Short nickname for the associated project."
-    :accessor eglot--project-nickname)
+    :accessor eglot--project-nickname
+    :reader eglot-project-nickname)
    (major-mode
     :documentation "Major mode symbol."
     :accessor eglot--major-mode)
@@ -906,7 +907,7 @@ in project `%s'."
                            (or (plist-get serverInfo :name)
                                (jsonrpc-name server))
                            managed-major-mode
-                           (eglot--project-nickname server))
+                           (eglot-project-nickname server))
                           (when tag (throw tag t))))
                       :timeout eglot-connect-timeout
                       :error-fn (eglot--lambda ((ResponseError) code message)
@@ -1172,7 +1173,7 @@ and just return it.  PROMPT shouldn't end with a question mark."
                           being hash-values of eglot--servers-by-project
                           append servers))
         (name (lambda (srv)
-                (format "%s/%s" (eglot--project-nickname srv)
+                (format "%s/%s" (eglot-project-nickname srv)
                         (eglot--major-mode srv)))))
     (cond ((null servers)
            (eglot--error "No servers!"))
@@ -1390,7 +1391,7 @@ Uses THING, FACE, DEFS and PREPEND."
 (defun eglot--mode-line-format ()
   "Compose the EGLOT's mode-line."
   (pcase-let* ((server (eglot-current-server))
-               (nick (and server (eglot--project-nickname server)))
+               (nick (and server (eglot-project-nickname server)))
                (pending (and server (hash-table-count
                                      (jsonrpc--request-continuations server))))
                (`(,_id ,doing ,done-p ,_detail) (and server (eglot--spinner server)))

--- a/eglot.el
+++ b/eglot.el
@@ -1234,6 +1234,19 @@ For example, to keep your Company customization use
 (defvar-local eglot--cached-server nil
   "A cached reference to the current EGLOT server.")
 
+(defun eglot-managed-p ()
+  "Tell if current buffer is managed by EGLOT."
+  eglot--managed-mode)
+
+(make-obsolete-variable
+ 'eglot--managed-mode-hook 'eglot-managed-mode-hook "1.6")
+
+(defvar eglot-managed-mode-hook nil
+  "A hook run by EGLOT after it starts/stops managing a buffer.
+Use `eglot-managed-p' in the hook function to determine whether
+EGLOT starts or stops managing a buffer, it returns t or nil,
+respectively.")
+
 (define-minor-mode eglot--managed-mode
   "Mode for source buffers managed by some EGLOT project."
   nil nil eglot-mode-map
@@ -1289,7 +1302,9 @@ For example, to keep your Company customization use
               (delq (current-buffer) (eglot--managed-buffers server)))
         (when (and eglot-autoshutdown
                    (null (eglot--managed-buffers server)))
-          (eglot-shutdown server)))))))
+          (eglot-shutdown server))))))
+  ;; Note: the public hook runs before the internal eglot--managed-mode-hook.
+  (run-hooks 'eglot-managed-mode-hook))
 
 (defun eglot--managed-mode-off ()
   "Turn off `eglot--managed-mode' unconditionally."


### PR DESCRIPTION
This is the second iteration of #364.  (Is it OK to create a new pull request or is it better to overwrite the old branch?  I was afraid the discussion would be removed as well.) 

It addresses a portion of #354 (Make some private variables/functions public)

I've removed define-obsolete-variable-alias from eglot--managed-mode-hook because it made the values of the eglot--managed-mode-hook and eglot-managed-mode-hook the same and therefore their contents were called twice.  However, I think we should somehow advertise the new public hook to 3rd parties.
