### PR TITLE
eglot-completion-at-point: Fix return values

### DIFF
--- a/eglot-tests.el
+++ b/eglot-tests.el
@@ -450,6 +450,22 @@ Pass TIMEOUT to `eglot--with-timeout'."
       (completion-at-point)
       (should (looking-back "sys.exit")))))
 
+(ert-deftest non-unique-completions ()
+  "Test completion resulting in 'Complete, but not unique'"
+  (skip-unless (executable-find "pyls"))
+  (eglot--with-fixture
+      '(("project" . (("something.py" . "foo=1\nfoobar=2\nfoo"))))
+    (with-current-buffer
+        (eglot--find-file-noselect "project/something.py")
+      (should (eglot--tests-connect))
+      (goto-char (point-max))
+      (completion-at-point))
+    (with-current-buffer (messages-buffer)
+      (save-excursion
+        (goto-char (point-max))
+        (forward-line -1)
+        (should (looking-at "Complete, but not unique"))))))
+
 (ert-deftest basic-xref ()
   "Test basic xref functionality in a python LSP"
   (skip-unless (executable-find "pyls"))

--- a/eglot.el
+++ b/eglot.el
@@ -2017,10 +2017,10 @@ is not active."
          (cond
           ((eq action 'metadata) metadata)               ; metadata
           ((eq action 'lambda)                           ; test-completion
-           (member probe (funcall proxies)))
+           (test-completion probe (funcall proxies)))
           ((eq (car-safe action) 'boundaries) nil)       ; boundaries
-          ((and (null action)                            ; try-completion
-                (member probe (funcall proxies)) t))
+          ((null action)                                 ; try-completion
+           (try-completion probe (funcall proxies)))
           ((eq action t)                                 ; all-completions
            (cl-remove-if-not
             (lambda (proxy)


### PR DESCRIPTION
The proposed commit log is below.  But once again, I mostly don't know what I'm doing, but the readily available functions (test-completion and try-completion) seems to do what needs to be done.  At least the tests pass. 

Tangentially I wonder whether there is a flex-matching alternative of these functions, or it is possible to globally change the behavior of these functions.

----
Fix #365.

The test-completion case shouldn't return t when there are multiple
matches.  Similarly, the try-completion should return t only if the
match is exact.  See (info "(elisp)Programmed Completion").

* eglot.el (eglot-completion-at-point): Instead of testing
memberships, use test-completion and try-completion suggested
by (info "(elisp)Programmed Completion").