### PR TITLE
Let us run just one test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Variables
 #
 EMACS=emacs
-SELECTOR=t
+SELECTOR ?=t
 
 LOAD_PATH=-L .
 


### PR DESCRIPTION
When I try to fix a bug, I usually want to check the result of just
one test.  This patch allows us to run:

SELECTOR='"basic-completion"' ELPADEPS="--eval '(package-initialize)'" make check

* Makefile: Make SELECTOR configurable from command line.