### PR TITLE
fix kill-buffer breakage due to auto-shutdown or public hook errors

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1306,8 +1306,8 @@ Use `eglot-managed-p' to determine if current buffer is managed.")
   (run-hooks 'eglot-managed-mode-hook))
 
 (defun eglot--managed-mode-off ()
-  "Turn off `eglot--managed-mode' unconditionally."
-  (eglot--managed-mode -1))
+  "Turn off `eglot--managed-mode' unconditionally, ignoring any errors."
+  (ignore-errors (eglot--managed-mode -1)))
 
 (defun eglot-current-server ()
   "Return logical EGLOT server for current buffer, nil if none."


### PR DESCRIPTION
eglot.el (eglot--managed-mode-off): ignore-errors, safe for hook use

If a managed buffer is killed, it runs `kill-buffer-hook` first.  An
error in either a server shutdown (due to `eglot-autoshutdown` enabled)
or the public `eglot-managed-mode-hook` will prevent the buffer from
actually being killed.
