### PR TITLE
Create match xrefs when possible.

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1832,8 +1832,8 @@ Calls REPORT-FN maybe if server publishes diagnostics in time."
        (maphash (lambda (_uri buf) (kill-buffer buf)) eglot--temp-location-buffers)
        (clrhash eglot--temp-location-buffers))))
 
-(defun eglot--xref-make (name uri range)
-  "Like `xref-make' but with LSP's NAME, URI and RANGE.
+(defun eglot--xref-make-match (name uri range)
+  "Like `xref-make-match' but with LSP's NAME, URI and RANGE.
 Try to visit the target file for a richer summary line."
   (pcase-let*
       ((file (eglot--uri-to-path uri))
@@ -1848,8 +1848,9 @@ Try to visit the target file for a richer summary line."
                                 (hi-end (- (min (point-at-eol) end) bol)))
                      (add-face-text-property hi-beg hi-end 'highlight
                                              t substring)
-                     (list substring (1+ (current-line)) (eglot-current-column))))))
-       (`(,summary ,line ,column)
+                     (list substring (1+ (current-line)) (eglot-current-column)
+                           (- end beg))))))
+       (`(,summary ,line ,column ,length)
         (cond
          (visiting (with-current-buffer visiting (funcall collect)))
          ((file-readable-p file) (with-current-buffer
@@ -1858,9 +1859,12 @@ Try to visit the target file for a richer summary line."
                                    (insert-file-contents file)
                                    (funcall collect)))
          (t ;; fall back to the "dumb strategy"
-          (let ((start (cl-getf range :start)))
-            (list name (1+ (cl-getf start :line)) (cl-getf start :character)))))))
-    (xref-make summary (xref-make-file-location file line column))))
+          (let* ((start (cl-getf range :start))
+                 (line (1+ (cl-getf start :line)))
+                 (start-pos (cl-getf start :character))
+                 (end-pos (cl-getf (cl-getf range :end) :character)))
+            (list name line start-pos (- end-pos start-pos)))))))
+    (xref-make-match summary (xref-make-file-location file line column) length)))
 
 (cl-defmethod xref-backend-identifier-completion-table ((_backend (eql eglot)))
   (eglot--error "cannot (yet) provide reliable completion table for LSP symbols"))
@@ -1891,7 +1895,7 @@ Try to visit the target file for a richer summary line."
     (eglot--collecting-xrefs (collect)
       (mapc
        (eglot--lambda ((Location) uri range)
-         (collect (eglot--xref-make (symbol-at-point) uri range)))
+         (collect (eglot--xref-make-match (symbol-at-point) uri range)))
        (if (vectorp response) response (list response))))))
 
 (cl-defun eglot--lsp-xref-helper (method &key extra-params capability )
@@ -1934,7 +1938,7 @@ Try to visit the target file for a richer summary line."
       (mapc
        (eglot--lambda ((SymbolInformation) name location)
          (eglot--dbind ((Location) uri range) location
-           (collect (eglot--xref-make name uri range))))
+           (collect (eglot--xref-make-match name uri range))))
        (jsonrpc-request (eglot--current-server-or-lose)
                         :workspace/symbol
                         `(:query ,pattern))))))


### PR DESCRIPTION
"Match xrefs" are created with `xref-make-match' instead of
`xref-make'.  Match xrefs support `xref-query-replace-in-results' from
the results buffer.

* eglot.el (eglot--xref-make-match): Calculate xref match length from
  the eglot range.