### PR TITLE
Improve reliability of python-autopep-formatting test.

### DIFF
--- a/eglot-tests.el
+++ b/eglot-tests.el
@@ -576,14 +576,8 @@ def foobazquuz(d, e, f): pass
 (ert-deftest python-autopep-formatting ()
   "Test formatting in the pyls python LSP.
 pyls prefers autopep over yafp, despite its README stating the contrary."
-  ;; For some reason Travis will fail the part of the test where we
-  ;; try to reformat just the second line, i.e. it will _not_ add
-  ;; newlines before the region we asked to reformat.  I actually
-  ;; think Travis' behaviour is more sensible, but I don't know how to
-  ;; reproduce it locally.  Must be some Python version thing.
   ;; Beware, default autopep rules can change over time, which may
   ;; affect this test.
-  (skip-unless (null (getenv "TRAVIS_TESTING")))
   (skip-unless (and (executable-find "pyls")
                     (executable-find "autopep8")))
   (eglot--with-fixture

--- a/eglot-tests.el
+++ b/eglot-tests.el
@@ -84,7 +84,11 @@ then restored."
              (set (car spec) (cadr spec)))
             ((stringp (car spec)) (push spec file-specs))))
     (unwind-protect
-        (let ((eglot-server-initialized-hook
+        (let ((process-environment
+               ;; Prevent user-configuration to have an influence on
+               ;; language servers. (See github#441)
+               (cons "XDG_CONFIG_HOME=/dev/null" process-environment))
+              (eglot-server-initialized-hook
                (lambda (server) (push server new-servers))))
           (setq created-files (mapcan #'eglot--make-file-or-dir file-specs))
           (prog1 (funcall fn)
@@ -577,8 +581,8 @@ pyls prefers autopep over yafp, despite its README stating the contrary."
   ;; newlines before the region we asked to reformat.  I actually
   ;; think Travis' behaviour is more sensible, but I don't know how to
   ;; reproduce it locally.  Must be some Python version thing.
-  ;; Beware, this test is brittle if ~/.config/pycodestyle exists, or
-  ;; default autopep rules change, which has happened.
+  ;; Beware, default autopep rules can change over time, which may
+  ;; affect this test.
   (skip-unless (null (getenv "TRAVIS_TESTING")))
   (skip-unless (and (executable-find "pyls")
                     (executable-find "autopep8")))


### PR DESCRIPTION
```
    Enable `python-autopep-formatting` test in Travis
    
    The test actually succeeds. (Unrelated to the previous XDG_CONFIG_HOME
    change.)
    
    * eglot-tests.el (python-autopep-formatting): Remove conditional on
    environment variable "TRAVIS_TESTING".

    Close #441: shield tests from some user customizations
    
    Users' customization of Python indenting style in the standard
    XDG_CONFIG_HOME location of ~/.config/pycodestyle could cause spurious
    test failures. We prevent this and similar problems by overriding that
    environment variable in tests. If this turns out to hurt other
    language servers used in the test suite, we'll have to revisit.
    
    * eglot-tests.el (eglot--call-with-fixture): Temporarily set
    XDG_CONFIG_HOME to /dev/null.
```