### PR TITLE
Use text-mode for plaintext markup

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1109,6 +1109,7 @@ Doubles as an indicator of snippet support."
                  (list (plist-get markup :value)
                        (pcase (plist-get markup :kind)
                          ("markdown" 'gfm-view-mode)
+                         ("plaintext" 'text-mode)
                          (_ major-mode))))))
     (with-temp-buffer
       (insert string)


### PR DESCRIPTION
For example, we have this python file:
```python
def foo(bar):
    """docstring for foo with reserved keywords or
string's opening."""
    pass

foo
```

Point is on the last line, `M-x eglot-help-at-point`.

Let's assume this client-server conversation:

```
client-request (id:129) Thu Apr 23 23:05:56 2020:
(:jsonrpc "2.0" :id 129 :method "textDocument/hover" :params
          (:textDocument
           (:uri "file:///Users/mad/test.py")
           :position
           (:line 5 :character 3)))

server-reply (id:129) Thu Apr 23 23:05:56 2020:
(:id 129 :jsonrpc "2.0" :result
     (:contents
      (:kind "plaintext" :value "foo(bar)\n\ndocstring for foo with reserved keywords or\nstring's opening.")
      :range nil))
```

`python-mode` is used to handle `value` because `kind` is not `markdown`. As result help buffer looks a little strange.

This PR make eglot use text-mode for plaintext markup.