### PR TITLE
Add tests of eglot--guess-contact, including a failing one, then fix it

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -690,7 +690,8 @@ be guessed."
          (class (or (and (consp guess) (symbolp (car guess))
                          (prog1 (car guess) (setq guess (cdr guess))))
                     'eglot-lsp-server))
-         (program (and (listp guess) (stringp (car guess)) (car guess)))
+         (program (and (listp guess)
+                       (stringp (car guess)) (stringp (cadr guess)) (car guess)))
          (base-prompt
           (and interactive
                "Enter program to execute (or <host>:<port>): "))

--- a/eglot.el
+++ b/eglot.el
@@ -120,15 +120,15 @@ of those modes.  CONTACT can be:
   over the standard input/output channels.
 
 * A list (HOST PORT [TCP-ARGS...]) where HOST is a string and PORT is
-  na positive integer number for connecting to a server via TCP.
+  a positive integer for connecting to a server via TCP.
   Remaining ARGS are passed to `open-network-stream' for
   upgrading the connection with encryption or other capabilities.
 
 * A list (PROGRAM [ARGS...] :autoport [MOREARGS...]), whereby a
-  combination of the two previous options is used..  First, an
+  combination of the two previous options is used.  First, an
   attempt is made to find an available server port, then PROGRAM
   is launched with ARGS; the `:autoport' keyword substituted for
-  that number; and MOREARGS.  Eglot then attempts to to establish
+  that number; and MOREARGS.  Eglot then attempts to establish
   a TCP connection to that port number on the localhost.
 
 * A cons (CLASS-NAME . INITARGS) where CLASS-NAME is a symbol


### PR DESCRIPTION
See #447. This PR adds unit test coverage for `eglot--guess-contact`. I believe that there is at least one bug in master, which these tests reveal: the `(host-string port-int)` version fails with `(wrong-type-argument stringp ...)`.

@joaotavora I have time to work on this if it's helpful, but would you be able to help me nail down the test assertions here? I've left some TODOs in the test code and will comment inline to make the discussion as concrete as possible. (Or of course feel free to complete the test cases added here yourself!)