### PR TITLE
Tests: print contents of *EGLOT ...* buffers in batch mode.

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -790,11 +790,19 @@ INTERACTIVE is t if called interactively."
   (interactive (list (eglot--current-server-or-lose)))
   (jsonrpc-forget-pending-continuations server))
 
-(defvar eglot-connect-hook nil "Hook run after connecting in `eglot--connect'.")
+(defvar eglot-connect-hook
+  '(eglot-signal-didChangeConfiguration)
+  "Hook run after connecting in `eglot--connect'.")
 
 (defvar eglot-server-initialized-hook
-  '(eglot-signal-didChangeConfiguration)
-  "Hook run after server is successfully initialized.
+  '()
+  "Hook run after a `eglot-lsp-server' instance is created.
+
+That is before a connection was established. Use
+`eglot-connect-hook' to hook into when a connection was
+successfully established and the server on the other side has
+received the initializing configuration.
+
 Each function is passed the server as an argument")
 
 (defun eglot--connect (managed-major-mode project class contact)
@@ -851,6 +859,7 @@ This docstring appeases checkdoc, that's all."
     (setf (eglot--project-nickname server) nickname)
     (setf (eglot--major-mode server) managed-major-mode)
     (setf (eglot--inferior-process server) autostart-inferior-process)
+    (run-hook-with-args 'eglot-server-initialized-hook server)
     ;; Now start the handshake.  To honour `eglot-sync-connect'
     ;; maybe-sync-maybe-async semantics we use `jsonrpc-async-request'
     ;; and mimic most of `jsonrpc-request'.
@@ -898,8 +907,7 @@ This docstring appeases checkdoc, that's all."
                           (let ((default-directory (car (project-roots project)))
                                 (major-mode managed-major-mode))
                             (hack-dir-local-variables-non-file-buffer)
-                            (run-hook-with-args 'eglot-connect-hook server)
-                            (run-hook-with-args 'eglot-server-initialized-hook server))
+                            (run-hook-with-args 'eglot-connect-hook server))
                           (eglot--message
                            "Connected! Server `%s' now managing `%s' buffers \
 in project `%s'."


### PR DESCRIPTION
```
    Tests: print contents of *EGLOT ...* buffers in batch mode.
    
    Useful for the CI on github. To be able to see more of the context of
    a failure.
    
    * eglot.el (eglot-server-initialized-hook): Changed semantics. Now
    called when an instance of `eglot-lsp-server' is created as part of
    the "connect to server" flow. Previously, there was no difference
    between this hook and `eglot-connect-hook' which continues to be run
    once a connection was successfully established. The
    `eglot-server-initialized-hook' will now capture ALL server instances
    including those that failed to be started. This change was necessary
    to make the test suite be able to dump the output of processes that
    fail to start when running the test suite in batch mode ("make check"
    and the CI.) In PR #448 it was decided that it is ok to change the
    semantics of this hook rather than introducing a new hook.
    (eglot--connect): Change place of where the hook is run.
    (eglot-connect-hook): Initialized now with
    `eglot-signal-didChangeConfiguration' which was kept in
    `eglot-server-initialized-hook' before.
    
    * eglot-tests.el (eglot--call-with-fixture): Use
    `eglot-server-initialized-hook' rather than `eglot-connect-hook'. And
    dump the contents of the *EGLOT ...* buffers when run in
    `noninteractive' (i.e. batch) mode.
    (eglot--cleanup-after-test): New auxiliary function. Extracted
    verbatim out of `eglot--call-with-fixture` in order to lower the
    latter's LOC.

```