### PR TITLE
Trim eldoc-message string

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1112,15 +1112,14 @@ Doubles as an indicator of snippet support."
 (defun eglot--format-markup (markup)
   "Format MARKUP according to LSP's spec."
   (pcase-let ((`(,string ,mode)
-               (if (stringp markup) (list (string-trim markup)
-                                          (intern "gfm-view-mode"))
+               (if (stringp markup) (list markup (intern "gfm-view-mode"))
                  (list (plist-get markup :value)
                        (pcase (plist-get markup :kind)
                          ("markdown" 'gfm-view-mode)
                          ("plaintext" 'text-mode)
                          (_ major-mode))))))
     (with-temp-buffer
-      (insert string)
+      (insert (string-trim string))
       (ignore-errors (delay-mode-hooks (funcall mode)))
       (font-lock-ensure)
       (buffer-string))))


### PR DESCRIPTION
* eglot.el: (eglot--format-markup): Factor string trim out
so we string-trim for all cases

In `elm-mode` all signatures are delivered with "\n" at the front, so when we show the signature in eldoc we get the empty string. Especially after #443 this becomes a problem. I don't think this interferes with anything other than that.

Also, is the `(intern "gfm-view-mode)` necessary? is it possible to just use `'gfm-view-mode`? 