### PR TITLE
Close #453: Show only signature when eldoc variable is set to nil

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2288,41 +2288,46 @@ Buffer is displayed with `display-buffer', which obeys
 `display-buffer-alist' & friends."
   :type 'boolean)
 
+(defun eglot--first-line-of-doc (string)
+  (truncate-string-to-width
+   (replace-regexp-in-string "\\(.*\\)\n.*" "\\1" string)
+   (frame-width) nil nil "..."))
+
 (defun eglot--update-doc (string hint)
   "Put updated documentation STRING where it belongs.
-Honours `eglot-put-doc-in-help-buffer'.  HINT is used to
+Honours `eglot-put-doc-in-help-buffer',`eglot-auto-display-help-buffer' and
+`eldoc-echo-area-use-multiline-p'.
+
+To show only signature information, set `eglot-put-doc-in-help-buffer' and
+`eldoc-echo-area-use-multiline-p' to NIL.  HINT is used to
 potentially rename EGLOT's help buffer.  If STRING is nil, the
 echo area cleared of any previous documentation."
-  (cond ((and string
-              (or (eq t eglot-put-doc-in-help-buffer)
-                  (and eglot-put-doc-in-help-buffer
-                       (funcall eglot-put-doc-in-help-buffer string))))
-         (with-current-buffer (eglot--help-buffer)
-           (let ((inhibit-read-only t)
-                 (name (format "*eglot-help for %s*" hint)))
-             (unless (string= name (buffer-name))
-               (rename-buffer (format "*eglot-help for %s*" hint))
-               (erase-buffer)
-               (insert string)
-               (goto-char (point-min)))
-             (if eglot-auto-display-help-buffer
-                 (display-buffer (current-buffer))
-               (unless (get-buffer-window (current-buffer))
-                 (eglot--message
-                  "%s\n(...truncated. Full help is in `%s')"
-                  (truncate-string-to-width
-                   (replace-regexp-in-string "\\(.*\\)\n.*" "\\1" string)
-                   (frame-width) nil nil "...")
-                  (buffer-name eglot--help-buffer))))
-             (help-mode))))
-        (eldoc-echo-area-use-multiline-p
-         (eldoc-message string))
-        (t
-         (eldoc-message
-          (and string
-               (if (string-match "\n" string)
-                   (substring string (match-end 0))
-                 string))))))
+  (if string
+      (cond ((or (eq t eglot-put-doc-in-help-buffer)
+                 (and eglot-put-doc-in-help-buffer
+                      (funcall eglot-put-doc-in-help-buffer string)))
+             (with-current-buffer (eglot--help-buffer)
+               (let ((inhibit-read-only t)
+                     (name (format "*eglot-help for %s*" hint)))
+                 (unless (string= name (buffer-name))
+                   (rename-buffer (format "*eglot-help for %s*" hint))
+                   (erase-buffer)
+                   (insert string)
+                   (goto-char (point-min)))
+                 (if eglot-auto-display-help-buffer
+                     (display-buffer (current-buffer))
+                   (unless (get-buffer-window (current-buffer))
+                     (eglot--message
+                      "%s\n(...truncated. Full help is in `%s')"
+                      (eglot--first-line-of-doc string)
+                      (buffer-name eglot--help-buffer))))
+                 (help-mode))))
+            (eldoc-echo-area-use-multiline-p
+             (eldoc-message string))
+            (t
+             (eldoc-message
+              (eglot--first-line-of-doc string))))
+    (eldoc-message string)))
 
 (defun eglot-eldoc-function ()
   "EGLOT's `eldoc-documentation-function' function."


### PR DESCRIPTION
ref #443 : proposal for how to handle single line signature information in eldoc-message