### PR TITLE
Possibility to show full first line of hover info

### DIFF
--- a/eglot-tests.el
+++ b/eglot-tests.el
@@ -573,6 +573,32 @@ def foobazquuz(d, e, f): pass
        (while (not eldoc-last-message) (accept-process-output nil 0.1))
        (should (string-match "^exit" eldoc-last-message))))))
 
+(ert-deftest hover-multiline-doc-locus ()
+  "Test if suitable amount of lines of hover info are shown."
+  (skip-unless (executable-find "pyls"))
+  (eglot--with-fixture
+      `(("project" . (("hover-first.py" . "from datetime import datetime")))
+        (eglot-put-doc-in-help-buffer nil)
+        ,@eglot--tests--python-mode-bindings)
+    (with-current-buffer
+        (eglot--find-file-noselect "project/hover-first.py")
+      (should (eglot--tests-connect))
+      (goto-char (point-max))
+      ;; one-line
+      (setq eldoc-last-message nil)
+      (setq-local eldoc-echo-area-use-multiline-p nil)
+      (eglot-eldoc-function)
+      (while (not eldoc-last-message) (accept-process-output nil 0.1))
+      (should (string-match "datetime" eldoc-last-message))
+      (should (not (cl-find ?\n eldoc-last-message)))
+      ;; multi-line
+      (setq eldoc-last-message nil)
+      (setq-local eldoc-echo-area-use-multiline-p t)
+      (eglot-eldoc-function)
+      (while (not eldoc-last-message) (accept-process-output nil 0.1))
+      (should (string-match "datetime" eldoc-last-message))
+      (should (cl-find ?\n eldoc-last-message)))))
+
 (ert-deftest python-autopep-formatting ()
   "Test formatting in the pyls python LSP.
 pyls prefers autopep over yafp, despite its README stating the contrary."

--- a/eglot.el
+++ b/eglot.el
@@ -2281,24 +2281,47 @@ is not active."
               (setq-local nobreak-char-display nil)))
         (display-local-help)))))
 
-(defun eglot-doc-too-large-for-echo-area (string)
-  "Return non-nil if STRING won't fit in echo area.
-Respects `max-mini-window-height' (which see)."
-  (let ((max-height
-         (cond ((floatp max-mini-window-height) (* (frame-height)
-                                                   max-mini-window-height))
-               ((integerp max-mini-window-height) max-mini-window-height)
-               (t 1))))
-    (> (cl-count ?\n string) max-height)))
+(cl-defun eglot-doc-too-large-for-echo-area
+    (string &optional (height max-mini-window-height))
+  "Return non-nil if STRING won't fit in echo area of height HEIGHT.
+HEIGHT defaults to `max-mini-window-height' (which see) and is
+interpreted like that variable.  If non-nil, the return value is
+the number of lines available."
+  (let ((available-lines (cl-typecase height
+                           (float (truncate (* (frame-height) height)))
+                           (integer height)
+                           (t 1))))
+    (when (> (1+ (cl-count ?\n string)) available-lines)
+      available-lines)))
+
+(cl-defun eglot--truncate-string (string height &optional (width (frame-width)))
+  "Return as much from STRING as fits in HEIGHT and WIDTH.
+WIDTH, if non-nil, truncates last line to those columns."
+  (cl-flet ((maybe-trunc
+             (str) (if width (truncate-string-to-width str width
+                                                       nil nil "...")
+                     str)))
+    (cl-loop
+     repeat height
+     for i from 1
+     for break-pos = (cl-position ?\n string)
+     for (line . rest) = (and break-pos
+                              (cons (substring string 0 break-pos)
+                                    (substring string (1+ break-pos))))
+     concat (cond (line (if (= i height) (maybe-trunc line) (concat line "\n")))
+                  (t (maybe-trunc string)))
+     while rest do (setq string rest))))
 
 (defcustom eglot-put-doc-in-help-buffer
+  ;; JT@2020-05-21: TODO: this variable should be renamed and the
+  ;; decision somehow be in eldoc.el itself.
   #'eglot-doc-too-large-for-echo-area
   "If non-nil, put \"hover\" documentation in separate `*eglot-help*' buffer.
 If nil, use whatever `eldoc-message-function' decides, honouring
 `eldoc-echo-area-use-multiline-p'.  If t, use `*eglot-help*'
-unconditionally.  If a function, it is called with the docstring
-to display and should a boolean producing one of the two previous
-values."
+unconditionally.  If a function, it is called with the
+documentation string to display and returns a generalized boolean
+interpreted as one of the two preceding values."
   :type '(choice (const :tag "Never use `*eglot-help*'" nil)
                  (const :tag "Always use `*eglot-help*'" t)
                  (function :tag "Ask a function")))
@@ -2308,11 +2331,6 @@ values."
 Buffer is displayed with `display-buffer', which obeys
 `display-buffer-alist' & friends."
   :type 'boolean)
-
-(defun eglot--first-line-of-doc (string)
-  (truncate-string-to-width
-   (replace-regexp-in-string "\\(.*\\)\n.*" "\\1" string)
-   (frame-width) nil nil "..."))
 
 (defun eglot--update-doc (string hint)
   "Put updated documentation STRING where it belongs.
@@ -2336,16 +2354,22 @@ documentation.  Honour `eglot-put-doc-in-help-buffer',
              (if eglot-auto-display-help-buffer
                  (display-buffer (current-buffer))
                (unless (get-buffer-window (current-buffer))
+                 ;; This prints two lines.  Should it print 1?  Or
+                 ;; honour max-mini-window-height?
                  (eglot--message
                   "%s\n(...truncated. Full help is in `%s')"
-                  (eglot--first-line-of-doc string)
+                  (eglot--truncate-string string 1 (- (frame-width) 8))
                   (buffer-name eglot--help-buffer))))
              (help-mode))))
-        (eldoc-echo-area-use-multiline-p
-         ;; Can't really honour non-t non-nil values if this var
-         (eldoc-message string))
+        ((eq eldoc-echo-area-use-multiline-p t)
+         (if-let ((available (eglot-doc-too-large-for-echo-area string)))
+             (eldoc-message (eglot--truncate-string string available))
+           (eldoc-message string)))
+        ((eq eldoc-echo-area-use-multiline-p 'truncate-sym-name-if-fit)
+         (eldoc-message (eglot--truncate-string string 1 nil)))
         (t
-         (eldoc-message (eglot--first-line-of-doc string)))))
+         ;; Can't (yet?) honour non-t non-nil values of this var
+         (eldoc-message (eglot--truncate-string string 1)))))
 
 (defun eglot-eldoc-function ()
   "EGLOT's `eldoc-documentation-function' function."


### PR DESCRIPTION
Let's continue our journey to perfect eldoc message! :)

This PR provides the possibility to show a full first line of the hover/signature info.

**Current behavior**

|`eldoc-echo-area-use-multiline-p` value|What part of the hover info we see in the echo area|
|-|-|
|`nil`|First line truncated to the frame width<br>*"Hey, where is the rest of the signature info? I just finished with the tenth arg of the func and want to know what the eleventh one is about!"*|
|non-nil|Last lines<br>*"Why, Eglot, why?"*|

**Proposed behavior**

|`eldoc-echo-area-use-multiline-p` value|What part of the hover info we see in the echo area|
|-|-|
|`nil`|First line truncated to the frame width<br>*"The echo area occupy only one line and doesn't break my shiny windows layout. Whoo-hoo!"*|
|`t`|Top lines<br>*"I can see as much hover info as the echo area can fit. Very informative! Awesome!"*|
|non-nil|Full first line<br>*"OMG this is the most convenient way to display hover and (especially) signature info! Great job, Eglot!"*|

**Bonus**

Honor `eglot--message` prefix length when truncating message.

`(setq eglot-put-doc-in-help-buffer t)`

The echo area content:

*Current behavior*

```
[eglot] datetime(year: int, month: int, day: int, hour: int=..., minute: int=...
, sec...
(...truncated. Full help is in `*eglot-help for datetime*')
```

*Proposed behavior*

```
[eglot] datetime(year: int, month: int, day: int, hour: int=..., minute: int=...
(...truncated. Full help is in `*eglot-help for datetime*')
```

Thanks!