### PR TITLE
Close #460: Fix "free variable" warning

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -810,7 +810,7 @@ INTERACTIVE is t if called interactively."
 (defun eglot-events-buffer (server)
   "Display events buffer for SERVER.
 Use current server's or first available Eglot events buffer."
-  (interactive (list eglot--cached-server))
+  (interactive (list (eglot-current-server)))
   (let ((buffer (if server (jsonrpc-events-buffer server)
                   (cl-find "\\*EGLOT.*events\\*"
                            (buffer-list)


### PR DESCRIPTION
* eglot.el (eglot-events-buffer): Use `eglot-current-server' instead
  of `eglot--cached-server' because the latter is declared later in
  the file.