### PR TITLE
Changed eglot-ignored-server-capabilites to set

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1163,35 +1163,34 @@ Doubles as an indicator of snippet support."
       (font-lock-ensure)
       (buffer-string))))
 
-(defcustom eglot-ignored-server-capabilites (list)
+(defcustom eglot-ignored-server-capabilites nil
   "LSP server capabilities that Eglot could use, but won't.
 You could add, for instance, the symbol
 `:documentHighlightProvider' to prevent automatic highlighting
 under cursor."
-  :type '(repeat
-          (choice
-           (const :tag "Documentation on hover" :hoverProvider)
-           (const :tag "Code completion" :completionProvider)
-           (const :tag "Function signature help" :signatureHelpProvider)
-           (const :tag "Go to definition" :definitionProvider)
-           (const :tag "Go to type definition" :typeDefinitionProvider)
-           (const :tag "Go to implementation" :implementationProvider)
-           (const :tag "Go to declaration" :implementationProvider)
-           (const :tag "Find references" :referencesProvider)
-           (const :tag "Highlight symbols automatically" :documentHighlightProvider)
-           (const :tag "List symbols in buffer" :documentSymbolProvider)
-           (const :tag "List symbols in workspace" :workspaceSymbolProvider)
-           (const :tag "Execute code actions" :codeActionProvider)
-           (const :tag "Code lens" :codeLensProvider)
-           (const :tag "Format buffer" :documentFormattingProvider)
-           (const :tag "Format portion of buffer" :documentRangeFormattingProvider)
-           (const :tag "On-type formatting" :documentOnTypeFormattingProvider)
-           (const :tag "Rename symbol" :renameProvider)
-           (const :tag "Highlight links in document" :documentLinkProvider)
-           (const :tag "Decorate color references" :colorProvider)
-           (const :tag "Fold regions of buffer" :foldingRangeProvider)
-           (const :tag "Execute custom commands" :executeCommandProvider)
-           (symbol :tag "Other"))))
+  :type '(set :tag "Ignored server features:" :greedy t
+              (const :tag "Documentation on hover" :hoverProvider)
+              (const :tag "Code completion" :completionProvider)
+              (const :tag "Function signature help" :signatureHelpProvider)
+              (const :tag "Go to definition" :definitionProvider)
+              (const :tag "Go to type definition" :typeDefinitionProvider)
+              (const :tag "Go to implementation" :implementationProvider)
+              (const :tag "Go to declaration" :implementationProvider)
+              (const :tag "Find references" :referencesProvider)
+              (const :tag "Highlight symbols automatically" :documentHighlightProvider)
+              (const :tag "List symbols in buffer" :documentSymbolProvider)
+              (const :tag "List symbols in workspace" :workspaceSymbolProvider)
+              (const :tag "Execute code actions" :codeActionProvider)
+              (const :tag "Code lens" :codeLensProvider)
+              (const :tag "Format buffer" :documentFormattingProvider)
+              (const :tag "Format portion of buffer" :documentRangeFormattingProvider)
+              (const :tag "On-type formatting" :documentOnTypeFormattingProvider)
+              (const :tag "Rename symbol" :renameProvider)
+              (const :tag "Highlight links in document" :documentLinkProvider)
+              (const :tag "Decorate color references" :colorProvider)
+              (const :tag "Fold regions of buffer" :foldingRangeProvider)
+              (const :tag "Execute custom commands" :executeCommandProvider)
+              (symbol :tag "Other")))
 
 (defun eglot--server-capable (&rest feats)
   "Determine if current server is capable of FEATS."


### PR DESCRIPTION
Hi, 

I was trying to deactivate automatic variable highlighting, and guessed `eglot-ignored-server-capabilites` was the right variable to deactivate this. Using the easy customisation interface to find out what values it accepts, I noticed that using `(repeat (choice ...))` was expressing the same thing as a `(set ...)` would do, just more accessibly. This changes that, with one caveat, namely that using `(set ...)` one can't express that a variable number of _other_ symbols can be members of the list. My recommendation would be not to have a _others_ field, because this implies undocumented features, which _should_ be part described in either the docstring or the type.

If you agree with the last point, I'll remove that too.