### PR TITLE
Add support for erlang

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ for the language you're using. Otherwise, it prompts you to enter one.
 * R's [languageserver][r-languageserver]
 * Dart's [dart_language_server][dart_language_server]
 * Elixir's [elixir-ls][elixir-ls]
+* Erlang's [erlang_ls][erlang_ls]
 * Ada's [ada_language_server][ada_language_server]
 * Scala's [metals][metals]
 * TeX/LaTeX's [Digestif][digestif]
@@ -525,6 +526,7 @@ Under the hood:
 [r-languageserver]: https://cran.r-project.org/package=languageserver
 [dart_language_server]: https://github.com/natebosch/dart_language_server
 [elixir-ls]: https://github.com/JakeBecker/elixir-ls
+[erlang_ls]: https://github.com/erlang-ls/erlang_ls
 [news]: https://github.com/joaotavora/eglot/blob/master/NEWS.md
 [ada_language_server]: https://github.com/AdaCore/ada_language_server
 [metals]: http://scalameta.org/metals/

--- a/eglot.el
+++ b/eglot.el
@@ -111,7 +111,8 @@ language-server/bin/php-language-server.php"))
                                 (ada-mode . ("ada_language_server"))
                                 (scala-mode . ("metals-emacs"))
                                 ((tex-mode context-mode texinfo-mode bibtex-mode)
-                                 . ("digestif")))
+                                 . ("digestif"))
+                                (erlang-mode . ("erlang_ls" "--transport" "stdio")))
   "How the command `eglot' guesses the server to start.
 An association list of (MAJOR-MODE . CONTACT) pairs.  MAJOR-MODE
 is a mode symbol, or a list of mode symbols.  The associated


### PR DESCRIPTION
- The erlang language server is at https://github.com/erlang-ls/erlang_ls

I believe this is a trivial change, but I have a copyright assignment for Emacs anyway.