### PR TITLE
Don't display flymake annotations when flymake is disabled

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1580,7 +1580,7 @@ COMMAND is a symbol naming the command."
                                              (t          'eglot-note))
                                        message `((eglot-lsp-diag . ,diag-spec)))))
          into diags
-         finally (cond (eglot--current-flymake-report-fn
+         finally (cond ((and flymake-mode eglot--current-flymake-report-fn)
                         (funcall eglot--current-flymake-report-fn diags
                                  ;; If the buffer hasn't changed since last
                                  ;; call to the report function, flymake won't


### PR DESCRIPTION
Fixes #468.

To reproduce this bug on master:

1. Create some buffer state that causes a flymake error/warning diagnostic to be displayed
2. Disable flymake mode with `M-x flymake-mode`. You will see the flymake overlay annotations disappear.
3. Do some activity in the buffer that triggers eglot diagnostic checking, such as inserting a newline. You will see the flymake overlay annotations reappear. This is a bug: they should only be displayed when flymake mode is active. 