### PR TITLE
Send point or region as code action range

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2534,12 +2534,9 @@ documentation.  Honour `eglot-put-doc-in-help-buffer',
 (defun eglot-code-actions (&optional beg end)
   "Get and offer to execute code actions between BEG and END."
   (interactive
-   (let (diags)
-     (cond ((region-active-p) (list (region-beginning) (region-end)))
-           ((setq diags (flymake-diagnostics (point)))
-            (list (cl-reduce #'min (mapcar #'flymake-diagnostic-beg diags))
-                  (cl-reduce #'max (mapcar #'flymake-diagnostic-end diags))))
-           (t (list (point-min) (point-max))))))
+   (if (region-active-p)
+       (list (region-beginning) (region-end))
+     (list (point) (point))))
   (unless (eglot--server-capable :codeActionProvider)
     (eglot--error "Server can't execute code actions!"))
   (let* ((server (eglot--current-server-or-lose))


### PR DESCRIPTION
*Trying to implement `refactor.inline` code action provided by [jedi](https://jedi.readthedocs.io/en/latest/docs/api.html#jedi.Script.inline).*

Looks like eglot never send the current point on `codeAction` request.

This PR aimed to send region boundaries when region is active and just the point otherwise:
- Each diagnostic contains its own range, there are no need to calculate `codeAction` range based on diagnostics under point.
- Exact point is certainly giving more context information to server than `(point-min) (point-max)`.