### PR TITLE
Prompt for executable when executable not found

### DIFF
--- a/eglot-tests.el
+++ b/eglot-tests.el
@@ -880,34 +880,62 @@ pyls prefers autopep over yafp, despite its README stating the contrary."
         (((CodeAction) title command)
          (list title command)))))))
 
-(cl-defmacro eglot--guessing-contact ((guessed-class-sym guessed-contact-sym)
+(cl-defmacro eglot--guessing-contact ((interactive-sym prompt-args-sym
+                                       guessed-class-sym guessed-contact-sym)
                                       &body body)
-  "Bind the result of `eglot--guess-contact' then evaluate BODY."
+  "Evaluate BODY twice, binding results of `eglot--guess-contact'.
+
+INTERACTIVE-SYM is bound to the boolean passed to
+`eglot--guess-contact' each time. If the user would have been
+prompted, PROMPT-ARGS-SYM is bound to the list of arguments that
+would have been passed to `read-shell-command', else nil.
+GUESSED-CLASS-SYM and GUESSED-CONTACT-SYM are bound to the useful
+return values of `eglot--guess-contact'. Unless the server
+program evaluates to \"a-missing-executable.exe\", this macro
+will assume it exists."
   (declare (indent 1) (debug t))
-  `(let ((buffer-file-name "_"))
-     (cl-destructuring-bind
-         (_ _ ,guessed-class-sym ,guessed-contact-sym)
-         (eglot--guess-contact)
-       ,@body)))
+  `(dolist (,interactive-sym '(nil t))
+     (let ((buffer-file-name "_")
+           (,prompt-args-sym nil))
+       (cl-letf (((symbol-function 'executable-find)
+                  (lambda (name) (unless (string-equal name "a-missing-executable.exe")
+                              (format "/totally-mock-bin/%s" name))))
+                 ((symbol-function 'read-shell-command)
+                  (lambda (&rest args) (setq ,prompt-args-sym args) "")))
+         (cl-destructuring-bind
+             (_ _ ,guessed-class-sym ,guessed-contact-sym)
+             (eglot--guess-contact ,interactive-sym)
+           ,@body)))))
 
 (ert-deftest eglot-server-programs-simple-executable ()
   (let ((eglot-server-programs '((foo-mode "some-executable")))
         (major-mode 'foo-mode))
-    (eglot--guessing-contact (guessed-class guessed-contact)
+    (eglot--guessing-contact (interactive-p prompt-args guessed-class guessed-contact)
+      (should (not prompt-args))
       (should (equal guessed-class 'eglot-lsp-server))
       (should (equal guessed-contact '("some-executable"))))))
+
+(ert-deftest eglot-server-programs-simple-missing-executable ()
+  (let ((eglot-server-programs '((foo-mode "a-missing-executable.exe")))
+        (major-mode 'foo-mode))
+    (eglot--guessing-contact (interactive-p prompt-args guessed-class guessed-contact)
+      (should (equal (not prompt-args) (not interactive-p)))
+      (should (equal guessed-class 'eglot-lsp-server))
+      (should (equal guessed-contact '("a-missing-executable.exe"))))))
 
 (ert-deftest eglot-server-programs-executable-multiple-major-modes ()
   (let ((eglot-server-programs '(((bar-mode foo-mode) "some-executable")))
         (major-mode 'foo-mode))
-    (eglot--guessing-contact (guessed-class guessed-contact)
+    (eglot--guessing-contact (interactive-p prompt-args guessed-class guessed-contact)
+      (should (not prompt-args))
       (should (equal guessed-class 'eglot-lsp-server))
       (should (equal guessed-contact '("some-executable"))))))
 
 (ert-deftest eglot-server-programs-executable-with-arg ()
   (let ((eglot-server-programs '((foo-mode "some-executable" "arg1")))
         (major-mode 'foo-mode))
-    (eglot--guessing-contact (guessed-class guessed-contact)
+    (eglot--guessing-contact (interactive-p prompt-args guessed-class guessed-contact)
+      (should (not prompt-args))
       (should (equal guessed-class 'eglot-lsp-server))
       (should (equal guessed-contact '("some-executable" "arg1"))))))
 
@@ -915,7 +943,8 @@ pyls prefers autopep over yafp, despite its README stating the contrary."
   (let ((eglot-server-programs '((foo-mode "some-executable" "arg1"
                                            :autoport "arg2")))
         (major-mode 'foo-mode))
-    (eglot--guessing-contact (guessed-class guessed-contact)
+    (eglot--guessing-contact (interactive-p prompt-args guessed-class guessed-contact)
+      (should (not prompt-args))
       (should (equal guessed-class 'eglot-lsp-server))
       (should (equal guessed-contact '("some-executable" "arg1"
                                        :autoport "arg2"))))))
@@ -923,7 +952,8 @@ pyls prefers autopep over yafp, despite its README stating the contrary."
 (ert-deftest eglot-server-programs-host-and-port ()
   (let ((eglot-server-programs '((foo-mode "somehost.example.com" 7777)))
         (major-mode 'foo-mode))
-    (eglot--guessing-contact (guessed-class guessed-contact)
+    (eglot--guessing-contact (interactive-p prompt-args guessed-class guessed-contact)
+      (should (not prompt-args))
       (should (equal guessed-class 'eglot-lsp-server))
       (should (equal guessed-contact '("somehost.example.com" 7777))))))
 
@@ -931,7 +961,8 @@ pyls prefers autopep over yafp, despite its README stating the contrary."
   (let ((eglot-server-programs '((foo-mode "somehost.example.com" 7777
                                            :type network)))
         (major-mode 'foo-mode))
-    (eglot--guessing-contact (guessed-class guessed-contact)
+    (eglot--guessing-contact (interactive-p prompt-args guessed-class guessed-contact)
+      (should (not prompt-args))
       (should (equal guessed-class 'eglot-lsp-server))
       (should (equal guessed-contact '("somehost.example.com" 7777
                                        :type network))))))
@@ -939,7 +970,8 @@ pyls prefers autopep over yafp, despite its README stating the contrary."
 (ert-deftest eglot-server-programs-class-name-and-plist ()
   (let ((eglot-server-programs '((foo-mode bar-class :init-key init-val)))
         (major-mode 'foo-mode))
-    (eglot--guessing-contact (guessed-class guessed-contact)
+    (eglot--guessing-contact (interactive-p prompt-args guessed-class guessed-contact)
+      (should (not prompt-args))
       (should (equal guessed-class 'bar-class))
       (should (equal guessed-contact '(:init-key init-val))))))
 
@@ -947,7 +979,8 @@ pyls prefers autopep over yafp, despite its README stating the contrary."
   (let ((eglot-server-programs '((foo-mode bar-class "some-executable" "arg1"
                                            :autoport "arg2")))
         (major-mode 'foo-mode))
-    (eglot--guessing-contact (guessed-class guessed-contact)
+    (eglot--guessing-contact (interactive-p prompt-args guessed-class guessed-contact)
+      (should (not prompt-args))
       (should (equal guessed-class 'bar-class))
       (should (equal guessed-contact '("some-executable" "arg1"
                                        :autoport "arg2"))))))
@@ -956,7 +989,8 @@ pyls prefers autopep over yafp, despite its README stating the contrary."
   (let ((eglot-server-programs '((foo-mode . (lambda (&optional _)
                                                '("some-executable")))))
         (major-mode 'foo-mode))
-    (eglot--guessing-contact (guessed-class guessed-contact)
+    (eglot--guessing-contact (interactive-p prompt-args guessed-class guessed-contact)
+      (should (not prompt-args))
       (should (equal guessed-class 'eglot-lsp-server))
       (should (equal guessed-contact '("some-executable"))))))
 

--- a/eglot.el
+++ b/eglot.el
@@ -704,7 +704,11 @@ be guessed."
                          (prog1 (car guess) (setq guess (cdr guess))))
                     'eglot-lsp-server))
          (program (and (listp guess)
-                       (stringp (car guess)) (stringp (cadr guess)) (car guess)))
+                       (stringp (car guess))
+                       ;; A second element might be the port of a (host, port)
+                       ;; pair, but in that case it is not a string.
+                       (or (null (cdr guess)) (stringp (cadr guess)))
+                       (car guess)))
          (base-prompt
           (and interactive
                "Enter program to execute (or <host>:<port>): "))


### PR DESCRIPTION
Fixes #474 @joaotavora @nemethf This PR introduces new failing tests at 5f25b764e5dd6c1743674e0da99f898a7583b174 then fixes them at 11c7e59d851daa2927bb17035054154d9de7b9d3. It extends the test coverage as follows:

- All tests now involve one check with the `interactive` argument of `eglot--guess-contact` set to `t`, and one with it set to `nil`, and we make new assertions regarding whether an interactive prompt was shown to the user, in both cases.
- In particular, we now check that the user is prompted for the executable if the contact spec appears to be for an executable, but it is not found.

This PR thus introduces 2 new dimensions to the test space:
1. interactive argument `t`/`nil`
2. executable `found`/`not-found`

Currently, rather than increase the number of tests by a factor of 4, what I have done is:

1. Use a `dolist` in the helper macro so that each test tests both interactive and non-interactive. My feeling is the extra coverage is valuable but duplicating all tests would be excessive and damage maintainability. Personally, my opinion is that the common case is that tests pass, and that it isn't that hard to figure out which iteration of a test parametrization loop is failing, if and when it comes to it. 
2. Add just one additional test case testing the case of a missing executable (it triggers a prompt).

Happy to hear other opinions here: I could duplicate more test cases, or add parametrization over executable found/not-found.

@joaotavora we did discuss the handling of executable found/not-found during PR review here: https://github.com/joaotavora/eglot/pull/446#discussion_r415085409, so just noting that this PR kind of goes back on our decision there.