### PR TITLE
Display flymake diagnostics along with documentation

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2268,12 +2268,15 @@ is not active."
     (let ((blurb (and (not (seq-empty-p contents))
                       (eglot--hover-info contents range))))
       (if blurb
-          (with-current-buffer (eglot--help-buffer)
-            (with-help-window (current-buffer)
-              (rename-buffer (format "*eglot-help for %s*"
-                                     (thing-at-point 'symbol)))
-              (with-current-buffer standard-output (insert blurb))
-              (setq-local nobreak-char-display nil)))
+          (let ((diagnostic (get-char-property (point) 'flymake-diagnostic)))
+            (with-current-buffer (eglot--help-buffer)
+              (with-help-window (current-buffer)
+                (rename-buffer (format "*eglot-help for %s*"
+                                       (thing-at-point 'symbol)))
+                (with-current-buffer standard-output (insert blurb))
+                (when diagnostic
+                  (insert "\n" (eglot--format-markup (flymake--diag-text diagnostic))))
+                (setq-local nobreak-char-display nil))))
         (display-local-help)))))
 
 (defun eglot-doc-too-large-for-echo-area (string)


### PR DESCRIPTION
I love the syntax-highlighted documentation provided by `eglot-help-at-point`. (I even bind it to `?` and use `C-u ?` for a literal question mark.) What I'm finding is that, in practice, when there is a compiler error at point, I'd like to see that error as part of the help output.

I understand that this may be mixing two sources of information -- one of which is flymake's concern. But is there any sympathy for this, in spirit at least? (the implementation here is just a quick proof-of-principle.) Or, am I missing a way to display syntax-highlighted diagnostics, or is there a different way this should be done?


<table>
  <thead>
    <td><emph>Before</emph></td>
    <td><emph>After</emph></td>
  </thead>
  <tr>
    <td>
      <img width=400px src="https://user-images.githubusercontent.com/52205/82125726-055ae700-9776-11ea-853f-8b9be574d80a.png" alt="image" />
    </td>
    <td>
      <img width=700px src="https://user-images.githubusercontent.com/52205/82125713-da709300-9775-11ea-95fb-117fa5a413d2.png" alt="image" />
    </td>
  </tr>
  <tr>
    <td>
      <img width=300px src="https://user-images.githubusercontent.com/52205/82125734-0db32200-9776-11ea-9dff-2fa356b62034.png" alt="image" />
    </td>
    <td>
      <img width=400px src="https://user-images.githubusercontent.com/52205/82125707-cc227700-9775-11ea-9743-f39dc6e66155.png" alt="image" />
    </td>
  </tr>
</table>
