### PR TITLE
Use filter-buffer-substring to get buffer text

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1162,10 +1162,10 @@ Doubles as an indicator of snippet support."
                          (_ major-mode))))))
     (with-temp-buffer
       (setq-local markdown-fontify-code-blocks-natively t)
-      (insert (string-trim string))
+      (insert string)
       (ignore-errors (delay-mode-hooks (funcall mode)))
       (font-lock-ensure)
-      (buffer-string))))
+      (string-trim (filter-buffer-substring (point-min) (point-max))))))
 
 (defcustom eglot-ignored-server-capabilites (list)
   "LSP server capabilities that Eglot could use, but won't.


### PR DESCRIPTION
Python file:

```python
int
```

`textDocument/hover` response:

```
(:id 44 :jsonrpc "2.0" :result
     (:contents
      (:kind "markdown" :value "```python\nint(x: Union[Text, bytes, SupportsInt, _SupportsIndex]=...)\nint(x: Union[Text, bytes, bytearray], base: int)\n```\n\n```\nint([x]) -> integer\nint(x, base=10) -> integer\n\nConvert a number or string to an integer, or return 0 if no arguments\nare given.  If x is a number, return x.__int__().  For floating point\nnumbers, this truncates towards zero.\n\nIf x is not a number or if base is given, then x must be a string,\nbytes, or bytearray instance representing an integer literal in the\ngiven base.  The literal can be preceded by '+' or '-' and be surrounded\nby whitespace.  The base defaults to 10.  Valid bases are 0 and 2-36.\nBase 0 means to interpret the base from the string as an integer literal.\n>>> int('0b100', base=0)\n4\n```")
      :range nil))
```

With default eglot settings the following message is shown in the echo area:
```
[eglot]
(...truncated. Full help is in `*eglot-help for int*')
```

Codeblock markers are invisible in `gfm-view-mode` and mostly useless after font faces are applied to the text.

This PR removes codeblock markers from the hover info.