### PR TITLE
Fix type error.

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1954,7 +1954,8 @@ Try to visit the target file for a richer summary line."
     (eglot--collecting-xrefs (collect)
       (mapc
        (eglot--lambda ((Location) uri range)
-         (collect (eglot--xref-make-match (symbol-at-point) uri range)))
+         (collect (eglot--xref-make-match (symbol-name (symbol-at-point))
+                                          uri range)))
        (if (vectorp response) response (list response))))))
 
 (cl-defun eglot--lsp-xref-helper (method &key extra-params capability )


### PR DESCRIPTION
‘eglot--xref-make-match’ expects a string NAME, but ‘symbol-at-point’ returns a
symbol.