### PR TITLE
Use temp directory as package-user-dir for installing ELPADEPS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ LOAD_PATH=-L .
 ELFILES := eglot.el eglot-tests.el
 ELCFILES := $(ELFILES:.el=.elc)
 
-ELPADEPS ?=--eval '(package-initialize)'			\
+ELPADEPS ?=--eval '(setq package-user-dir (expand-file-name "elpa-eglot-test" temporary-file-directory))'	\
+           --eval '(package-initialize)'			\
            --eval '(package-refresh-contents)'			\
            --eval '(package-install (quote company))'		\
            --eval '(package-install (quote jsonrpc))'		\


### PR DESCRIPTION
Avoid the installation of unneeded packages on `make eglot-check`.