### PR TITLE
Propagate exec-path and process-environment when calling make-process

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -854,6 +854,8 @@ This docstring appeases checkdoc, that's all."
   (let* ((default-directory (project-root project))
          (nickname (file-name-base (directory-file-name default-directory)))
          (readable-name (format "EGLOT (%s/%s)" nickname managed-major-mode))
+         (inferior-process-environment process-environment)
+         (inferior-process-exec-path exec-path)
          autostart-inferior-process
          (contact (if (functionp contact) (funcall contact) contact))
          (initargs
@@ -875,7 +877,9 @@ This docstring appeases checkdoc, that's all."
                 ((stringp (car contact))
                  `(:process
                    ,(lambda ()
-                      (let ((default-directory default-directory))
+                      (let ((default-directory default-directory)
+                            (process-environment inferior-process-environment)
+                            (exec-path inferior-process-exec-path))
                         (make-process
                          :name readable-name
                          :command contact


### PR DESCRIPTION
If either of these variables is set locally in a project or buffer, e.g. using directory-local variables or packages like `add-node-modules-path` and `envrc`, then the user will be able to "see" and execute the language server program from their buffer, but eglot will not be able to find it.

The appropriate fix is to explicitly propagate both vars to the started process, so that it acts as if it were started from the initiating buffer.

Thanks again for eglot!