### PR TITLE
Give before-/after-change-functions whole buffer

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2508,12 +2508,16 @@ documentation.  Honour `eglot-put-doc-in-help-buffer',
                                 (length (- end beg))
                                 (beg (marker-position beg))
                                 (end (marker-position end)))
-                            (run-hook-with-args 'before-change-functions
-                                                beg end)
+                            (save-restriction
+                              (widen)
+                              (run-hook-with-args 'before-change-functions
+                                                  beg end))
                             (replace-buffer-contents temp)
-                            (run-hook-with-args 'after-change-functions
-                                                beg (+ beg (length newText))
-                                                length))))
+                            (save-restriction
+                              (widen)
+                              (run-hook-with-args 'after-change-functions
+                                                  beg (+ beg (length newText))
+                                                  length)))))
                       (progress-reporter-update reporter (cl-incf done)))))))
             (mapcar (eglot--lambda ((TextEdit) range newText)
                       (cons newText (eglot--range-region range 'markers)))


### PR DESCRIPTION
This protects against bugs caused by mode-specific
before-change-functions and after-change-functions which assume that
they are in an unrestricted buffer.

Closes #497