### PR TITLE
Silence messages while formatting markup

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1166,7 +1166,8 @@ Doubles as an indicator of snippet support."
     (with-temp-buffer
       (setq-local markdown-fontify-code-blocks-natively t)
       (insert string)
-      (ignore-errors (delay-mode-hooks (funcall mode)))
+      (let ((inhibit-message t))
+        (ignore-errors (delay-mode-hooks (funcall mode))))
       (font-lock-ensure)
       (string-trim (filter-buffer-substring (point-min) (point-max))))))
 

--- a/eglot.el
+++ b/eglot.el
@@ -1166,7 +1166,8 @@ Doubles as an indicator of snippet support."
     (with-temp-buffer
       (setq-local markdown-fontify-code-blocks-natively t)
       (insert string)
-      (let ((inhibit-message t))
+      (let ((inhibit-message t)
+	    (message-log-max nil))
         (ignore-errors (delay-mode-hooks (funcall mode))))
       (font-lock-ensure)
       (string-trim (filter-buffer-substring (point-min) (point-max))))))


### PR DESCRIPTION
Prior to this, activating gfm-view-mode could echo messages like "markdown-mode math support enabled" to the minibuffer.

See #501 