### PR TITLE
Fix getting :sortText error when sorting completion items

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2053,12 +2053,15 @@ is not active."
   ;; Commit logs for this function help understand what's going on.
   (when-let (completion-capability (eglot--server-capable :completionProvider))
     (let* ((server (eglot--current-server-or-lose))
-           (sort-completions (lambda (completions)
-                               (sort completions
-                                     (lambda (a b)
-                                       (string-lessp
-                                        (or (get-text-property 0 :sortText a) "")
-                                        (or (get-text-property 0 :sortText b) ""))))))
+           (sort-completions
+            (lambda (completions)
+              (sort completions
+                    (lambda (a b)
+                      (string-lessp
+                       (or (plist-get
+                            (get-text-property 0 'eglot--lsp-item a) :sortText) "")
+                       (or (plist-get
+                            (get-text-property 0 'eglot--lsp-item b) :sortText) ""))))))
            (metadata `(metadata . ((display-sort-function . ,sort-completions))))
            resp items (cached-proxies :none)
            (proxies


### PR DESCRIPTION
This fixes the error that the completion items can not be sorted correctly according to `:sortText`, because getting `:sortText` content always fails. I have tested it with Microsoft's python language server and now it works right.