### PR TITLE
Godot engine support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ for the language you're using. Otherwise, it prompts you to enter one.
 * Ada's [ada_language_server][ada_language_server]
 * Scala's [metals][metals]
 * TeX/LaTeX's [Digestif][digestif]
+* Godot Engine's [built in LSP server][godot]
 
 I'll add to this list as I test more servers. In the meantime you can
 customize `eglot-server-programs`:
@@ -529,3 +530,4 @@ Under the hood:
 [flymake]: https://www.gnu.org/software/emacs/manual/html_node/flymake/index.html#Top
 [yasnippet]: http://elpa.gnu.org/packages/yasnippet.html
 [markdown]: https://github.com/defunkt/markdown-mode
+[godot]: https://godotengine.org

--- a/eglot.el
+++ b/eglot.el
@@ -121,7 +121,8 @@ language-server/bin/php-language-server.php"))
                                 (scala-mode . ("metals-emacs"))
                                 ((tex-mode context-mode texinfo-mode bibtex-mode)
                                  . ("digestif"))
-                                (erlang-mode . ("erlang_ls" "--transport" "stdio")))
+                                (erlang-mode . ("erlang_ls" "--transport" "stdio"))
+                                (gdscript-mode . ("localhost" 6008))
   "How the command `eglot' guesses the server to start.
 An association list of (MAJOR-MODE . CONTACT) pairs.  MAJOR-MODE
 is a mode symbol, or a list of mode symbols.  The associated


### PR DESCRIPTION
Added support for the Godot Game Engine by specifying localhost:6008 when entering GDScript mode.
Eglot should not attempt to start Godot itself, it should just attempt to connect to the port.

Closes #511