### PR TITLE
Forward-declare newer Eldoc symbols.

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -85,6 +85,13 @@
     (load "eldoc")
   (require 'eldoc))
 
+;; We need to forward-declare `eldoc' symbols because the byte compiler doesn't
+;; always understand the previous form.
+(defvar eldoc-documentation-strategy)
+(defvar eldoc-documentation-functions)
+(declare-function eldoc "eldoc" (&optional interactive))
+(declare-function eldoc-documentation-enthusiast "eldoc" ())
+
 ;; forward-declare, but don't require (Emacs 28 doesn't seem to care)
 (defvar markdown-fontify-code-blocks-natively)
 (defvar company-backends)


### PR DESCRIPTION
This appears to be sometimes necessary to suppress warnings, e.g., when using
Flymake in Emacs 27.  For some reason I can't reproduce the issue when running
`make', but in any case forward-declaring the symbols can't hurt.