### PR TITLE
Make the symbol name the default value when renaming

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2477,7 +2477,9 @@ is not active."
 (defun eglot-rename (newname)
   "Rename the current symbol to NEWNAME."
   (interactive
-   (list (read-from-minibuffer (format "Rename `%s' to: " (symbol-at-point)))))
+   (list (read-from-minibuffer (format "Rename `%s' to: " (symbol-at-point))
+                               nil nil nil nil
+                               (symbol-name (symbol-at-point)))))
   (unless (eglot--server-capable :renameProvider)
     (eglot--error "Server can't rename!"))
   (eglot--apply-workspace-edit


### PR DESCRIPTION
My expectation for renaming things is that I can M-n to get the original name to edit.