### PR TITLE
Added the symbol attribute 'eglot-language-id

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1670,9 +1670,11 @@ THINGS are either registrations or unregisterations (sic)."
   (append
    (eglot--VersionedTextDocumentIdentifier)
    (list :languageId
-         (if (string-match "\\(.*\\)-mode" (symbol-name major-mode))
-             (match-string 1 (symbol-name major-mode))
-           "unknown")
+	 (cond
+           ((get major-mode 'eglot-language-id))
+           ((string-match "\\(.*\\)-mode" (symbol-name major-mode))
+            (match-string 1 (symbol-name major-mode)))
+           (t "unknown"))
          :text
          (eglot--widening
           (buffer-substring-no-properties (point-min) (point-max))))))


### PR DESCRIPTION
This implements the fix proposed by https://github.com/joaotavora/eglot/issues/525#issuecomment-678540557 to the issue of languages whose major mode has a different name from the language themselves