### PR TITLE
Handle LSP 3.15 isPreferred code action property.

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -576,7 +576,8 @@ treated as in `eglot-dbind'."
                                      ["quickfix"
                                       "refactor" "refactor.extract"
                                       "refactor.inline" "refactor.rewrite"
-                                      "source" "source.organizeImports"])))
+                                      "source" "source.organizeImports"]))
+                                  :isPreferredSupport t)
              :formatting         `(:dynamicRegistration :json-false)
              :rangeFormatting    `(:dynamicRegistration :json-false)
              :rename             `(:dynamicRegistration :json-false)

--- a/eglot.el
+++ b/eglot.el
@@ -244,7 +244,7 @@ let the buffer grow forever."
 (eval-and-compile
   (defvar eglot--lsp-interface-alist
     `(
-      (CodeAction (:title) (:kind :diagnostics :edit :command))
+      (CodeAction (:title) (:kind :diagnostics :edit :command :isPreferred))
       (ConfigurationItem () (:scopeUri :section))
       (Command ((:title . string) (:command . string)) (:arguments))
       (CompletionItem (:label)
@@ -2516,12 +2516,14 @@ code actions at point"
                         (cons title all))
                       actions)
               (eglot--error "No code actions here")))
+         (preferred-item (plist-get (seq-find (jsonrpc-lambda (&key title &key isPreferred &allow-other-keys) isPreferred) actions) :title))
          (menu `("Eglot code actions:" ("dummy" ,@menu-items)))
          (action (if (listp last-nonmenu-event)
                      (x-popup-menu last-nonmenu-event menu)
                    (cdr (assoc (completing-read "[eglot] Pick an action: "
                                                 menu-items nil t
-                                                nil nil (car menu-items))
+                                                nil nil (or preferred-item
+                                                            (car menu-items)))
                                menu-items)))))
     (eglot--dcase action
       (((Command) command arguments)


### PR DESCRIPTION
Trying the clangd HEAD, eglot failed to handle codeAction replies correctly. It seems to be caused by the addition of the `isPreferred` property in LSP 3.15. This patch tries to handle the property correctly.