### PR TITLE
Surround ‘eldoc’ loading hack with ‘eval-and-compile’.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ ELPADEPS ?=--eval '(package-initialize)'                        \
            --eval '(install-latest (quote eldoc))'              \
            --eval '(unintern                                    \
                      (quote eldoc-documentation-function))'     \
-           --eval '(load "eldoc")'                              \
            --eval '(install-latest (quote company))'            \
            --eval '(install-latest (quote yasnippet))'          \
            --eval '(install-latest (quote flymake))'

--- a/eglot.el
+++ b/eglot.el
@@ -76,10 +76,11 @@
 ;; ElDoc is preloaded in Emacs, so `require'-ing won't guarantee we are
 ;; using the latest version from GNU Elpa when we load eglot.el.  Use an
 ;; heuristic to see if we need to `load' it in Emacs < 28.
-(if (and (< emacs-major-version 28)
-         (not (boundp 'eldoc-documentation-strategy)))
-    (load "eldoc")
-  (require 'eldoc))
+(eval-and-compile
+  (if (and (< emacs-major-version 28)
+           (not (boundp 'eldoc-documentation-strategy)))
+      (load "eldoc")
+    (require 'eldoc)))
 
 ;; forward-declare, but don't require (Emacs 28 doesn't seem to care)
 (defvar markdown-fontify-code-blocks-natively)


### PR DESCRIPTION
This ensures that the reloading also happens during byte compilation.  We then
don’t need the explicit ‘load’ in the Makefile any more.