### PR TITLE
Defined variable for customizing highlight face

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2345,6 +2345,7 @@ is not active."
     t))
 
 (defvar eglot--highlights nil "Overlays for textDocument/documentHighlight.")
+(defvar eglot--highlight-face 'highlight "Face for textDocument/documentHighlight overlays.")
 
 (defun eglot--highlight-piggyback (_cb)
   "Request and handle `:textDocument/documentHighlight'"
@@ -2365,7 +2366,7 @@ is not active."
                     (pcase-let ((`(,beg . ,end)
                                  (eglot--range-region range)))
                       (let ((ov (make-overlay beg end)))
-                        (overlay-put ov 'face 'highlight)
+                        (overlay-put ov 'face eglot--highlight-face)
                         (overlay-put ov 'evaporate t)
                         ov)))
                   highlights))))


### PR DESCRIPTION
With Doom Emacs dark theme the highlight background color was conflicting with the cursor's, making it hard to see and bothering more than helping. So I thought it would be nice to just be able to customize it.

With something like:
`(setq eglot--highlight-face '(:background "#223355"))`
