### PR TITLE
Close #583: Define a face for symbol highlight

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -166,6 +166,10 @@ of those modes.  CONTACT can be:
   should not ask the user for any input, and return nil or signal
   an error if it can't produce a valid CONTACT.")
 
+(defface eglot-highlight-symbol-face
+  '((t (:inherit bold)))
+  "Face used to highlight the symbol at point.")
+
 (defface eglot-mode-line
   '((t (:inherit font-lock-constant-face :weight bold)))
   "Face for package-name in EGLOT's mode line.")
@@ -2366,7 +2370,7 @@ is not active."
                     (pcase-let ((`(,beg . ,end)
                                  (eglot--range-region range)))
                       (let ((ov (make-overlay beg end)))
-                        (overlay-put ov 'face 'highlight)
+                        (overlay-put ov 'face 'eglot-highlight-symbol-face)
                         (overlay-put ov 'evaporate t)
                         ov)))
                   highlights))))


### PR DESCRIPTION
I decided to go for bold as the default `eglot-highlight-symbol-face`.  I'll outline my thinking here so that possible future objections can be evaluated.

I tried out the chosen face with the built-in themes, and agree with @rvlo (https://github.com/joaotavora/eglot/issues/583#issuecomment-754851909) that bold doesn't give enough emphasis to the highlighted symbols on dark or very busy themes.  On the other hand,

- It's guaranteed not to clash with other colors, an issue reported in https://github.com/joaotavora/eglot/pull/580 for the Doom theme and which I had experienced with Swiper.
- It works well with the default theme, which, by definition, is the only theme that can't redefine the face.
- It's consistent with Eldoc's highlight of the current function argument.

Finally, since the highlight symbol feature is potentially annoying, it seems reasonable to err on the side of caution and not be too flashy.  The chosen default still makes the feature discoverable.

(FWIW, I've initiated the copyright assignment paperwork)