### PR TITLE
Support optional :activeParameter property for SignatureInformation

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -276,7 +276,7 @@ let the buffer grow forever."
       (ShowMessageParams (:type :message))
       (ShowMessageRequestParams (:type :message) (:actions))
       (SignatureHelp (:signatures) (:activeSignature :activeParameter))
-      (SignatureInformation (:label) (:documentation :parameters))
+      (SignatureInformation (:label) (:documentation :parameters :activeParameter))
       (SymbolInformation (:name :kind :location)
                          (:deprecated :containerName))
       (DocumentSymbol (:name :range :selectionRange :kind)
@@ -2265,14 +2265,17 @@ is not active."
                          (if (vectorp contents) contents (list contents)) "\n")))
     (when (or heading (cl-plusp (length body))) (concat heading body))))
 
-(defun eglot--sig-info (sigs active-sig active-param)
+(defun eglot--sig-info (sigs active-sig sig-help-active-param)
   (cl-loop
    for (sig . moresigs) on (append sigs nil) for i from 0
    concat
-   (eglot--dbind ((SignatureInformation) label documentation parameters) sig
+   (eglot--dbind ((SignatureInformation) label documentation parameters activeParameter) sig
      (with-temp-buffer
        (save-excursion (insert label))
-       (let (params-start params-end)
+       (let ((active-param (or activeParameter
+                               sig-help-active-param))
+             params-start
+             params-end)
          ;; Ad-hoc attempt to parse label as <name>(<params>)
          (when (looking-at "\\([^(]+\\)(\\([^)]+\\))")
            (setq params-start (match-beginning 2) params-end (match-end 2))


### PR DESCRIPTION
* eglot.el (eglot--lsp-interface-alist): Add
SignatureInformation.activeParameter.

* eglot.el (eglot--sig-info): Prioritize
SignatureInformation.activeParameter over
SignatureHelp.activeParameter.

SignatureInformation.activeParameter is new in version 3.16.0 of the
protocol.  When non-nil, it is used in place of
SignatureHelp.activeParameter.

See https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_signatureHelp

I tested with this Python file, by hovering over the `arr` in `len(arr)`:

``` python3
def hello():
    arr = [42]
    return len(arr)
```

And this server:

``` elisp
  (add-to-list 'eglot-server-programs '(python-mode . ("pyright-langserver" "--stdio")))
```

Oh, and I know it doesn't matter for this PR, but for future reference, I have filled out the FSF papers before, for the `ivy.el` package, so I don't think I need to submit them again?