### PR TITLE
Explicitly require seq.el

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -59,6 +59,7 @@
 (require 'imenu)
 (require 'cl-lib)
 (require 'project)
+(require 'seq)
 (require 'url-parse)
 (require 'url-util)
 (require 'pcase)


### PR DESCRIPTION
* eglot.el: Require seq.el.

`seq-empty-p' is not autoloaded in Emacs >= 26.3, so it must be
explicitly required.