### PR TITLE
eglot-client-capabilities: Indicate support for activeParameter

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -565,7 +565,8 @@ treated as in `eglot-dbind'."
              :signatureHelp      (list :dynamicRegistration :json-false
                                        :signatureInformation
                                        `(:parameterInformation
-                                         (:labelOffsetSupport t)))
+                                         (:labelOffsetSupport t)
+                                         :activeParameterSupport t))
              :references         `(:dynamicRegistration :json-false)
              :definition         `(:dynamicRegistration :json-false)
              :declaration        `(:dynamicRegistration :json-false)


### PR DESCRIPTION
* eglot.el (eglot-client-capabilities): Mention
:activeParameterSupport.

Fixup of commit 1f2b0241ca24d78edbd146d17daef6a0e6b2e4f3.