### PR TITLE
Split `eglot-code-actions` into smaller functions

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2527,9 +2527,10 @@ is not active."
 
 (defun eglot--code-actions-menu-items (beg &optional end action-kind)
   "List code actions between BEG and END.
-Interactively, if a region is active, BEG and END are its bounds,
-else BEG is point and END is nil, which results in a request for
-code actions at point"
+If END is nil, it results in the code actions available at the
+point defined by BEG, Otherwise BEG and END are its bounds. If
+ACTION-KIND is defined, will filter the results to show only
+actions of the provided kind"
   (unless (eglot--server-capable :codeActionProvider)
     (eglot--error "Server can't execute code actions!"))
   (let* ((server (eglot--current-server-or-lose))


### PR DESCRIPTION
## Problem description
Currently there's no way of changing `completing-read` for something else (eg.: helm) for listing/selecting an action from `eglot-code-actions`. 

## Proposed solution
This PR tries to solve this limitation by splitting the functionality and enabling one to use its parts. It basically divides the current implementation into a function to fetch the actions available, a function to execute an action chosen by the user, and a function to tie these two and present it using `completing-read` - preserving the current behavior.

An example of building upon these parts is presented in this gist. In it, I implemented the same functionality but using [helm](https://github.com/emacs-helm/helm) to present the actions, as it is my preferred tool. https://gist.github.com/caioaao/0fdfa0fc2d86ef1fbdfc39f509d62319

## Alternatives considered
- Add a custom variable so the user can pick which program to use for showing the code actions. 
  While this might be easier for people with less experience in elisp, it'd increase complexity of Eglot's code and put the burden of  supporting different customizations on to Eglot project.  