### PR TITLE
Remove highlight overlay immediately when symbol is edited

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2379,7 +2379,10 @@ is not active."
                                  (eglot--range-region range)))
                       (let ((ov (make-overlay beg end)))
                         (overlay-put ov 'face 'eglot-highlight-symbol-face)
-                        (overlay-put ov 'evaporate t)
+                        (overlay-put ov
+                                     'modification-hooks
+                                     `(,(lambda (ov &rest _more)
+                                          (delete-overlay ov))))
                         ov)))
                   highlights))))
        :deferred :textDocument/documentHighlight)


### PR DESCRIPTION
Currently, the `textDocument/documentHighlight` overlays stay when the highlighted symbol is edited, which is is distracting and arguably incorrect.

With this PR, the highlight disappears as soon as the symbol is edited (other highlights stick around, which feels right to me).