### PR TITLE
Fix #610: Handle empty uri on windows

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1176,10 +1176,8 @@ If optional MARKER, return a marker instead"
   "Convert URI to a file path."
   (when (keywordp uri) (setq uri (substring (symbol-name uri) 1)))
   (let ((retval (url-filename (url-generic-parse-url (url-unhex-string uri)))))
-    (if (and (eq system-type 'windows-nt)
-             (cl-plusp (length retval)))
-        (substring retval 1)
-      retval)))
+    (if (and (eq system-type 'windows-nt) (cl-plusp (length retval)))
+        (substring retval 1) retval)))
 
 (defun eglot--snippet-expansion-fn ()
   "Compute a function to expand snippets.

--- a/eglot.el
+++ b/eglot.el
@@ -1176,7 +1176,10 @@ If optional MARKER, return a marker instead"
   "Convert URI to a file path."
   (when (keywordp uri) (setq uri (substring (symbol-name uri) 1)))
   (let ((retval (url-filename (url-generic-parse-url (url-unhex-string uri)))))
-    (if (eq system-type 'windows-nt) (substring retval 1) retval)))
+    (if (and (eq system-type 'windows-nt)
+             (cl-plusp (length retval)))
+        (substring retval 1)
+      retval)))
 
 (defun eglot--snippet-expansion-fn ()
   "Compute a function to expand snippets.


### PR DESCRIPTION
* eglot.el (eglot--uri-to-path): make sure that we check whether we have a
nonempty string.  If we do, just return retval as on other operating systems.