### PR TITLE
Fix #635: Protect against zero-length proxy

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2133,7 +2133,7 @@ is not active."
                                        insertText)
                                       (t
                                        (string-trim-left label)))))
-                           (unless (zerop (length item))
+                           (unless (zerop (length proxy))
                              (put-text-property 0 1 'eglot--lsp-item item proxy))
                            proxy))
                        items)))))


### PR DESCRIPTION
It looks like the important element to zero-length check here is the `proxy` value. It fixes the bug reported in #635, and looks more like what should be done, given what the let-binding does here.