### PR TITLE
TRAMP support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # (upcoming)
 
+##### TRAMP support ([#637][github#637], ([#463][github#463], ([#84][github#84])
+
+Thanks, Brian Cully! 
+
+(also thanks to many early experiments conducted by Felipe Lema)
+
 ##### Code action shortcuts ([#411][github#411])
 
 `M-x eglot-code-actions` accepts an optional `action-kind` argument,
@@ -209,6 +215,7 @@ and now said bunch of references-->
 [github#81]: https://github.com/joaotavora/eglot/issues/81
 [github#82]: https://github.com/joaotavora/eglot/issues/82
 [github#83]: https://github.com/joaotavora/eglot/issues/83
+[github#84]: https://github.com/joaotavora/eglot/issues/84
 [github#86]: https://github.com/joaotavora/eglot/issues/86
 [github#87]: https://github.com/joaotavora/eglot/issues/87
 [github#93]: https://github.com/joaotavora/eglot/issues/93
@@ -248,5 +255,7 @@ and now said bunch of references-->
 [github#411]: https://github.com/joaotavora/eglot/issues/411
 [github#439]: https://github.com/joaotavora/eglot/issues/439
 [github#454]: https://github.com/joaotavora/eglot/issues/454
+[github#463]: https://github.com/joaotavora/eglot/issues/463
 [github#481]: https://github.com/joaotavora/eglot/issues/481
 [github#494]: https://github.com/joaotavora/eglot/issues/494
+[github#637]: https://github.com/joaotavora/eglot/issues/637

--- a/README.md
+++ b/README.md
@@ -180,6 +180,13 @@ See `eglot.el`'s section on Java's JDT server for an even more
 sophisticated example.
 
 <a name="reporting bugs"></a>
+
+## TRAMP support
+
+Should just work. Try `M-x eglot` in a buffer visiting a remote file
+where you've also installed the language server.  Only supported on
+Emacs 27.1.
+
 # Reporting bugs
 
 Having trouble connecting to a server?  Expected to have a certain

--- a/eglot-tests.el
+++ b/eglot-tests.el
@@ -947,9 +947,10 @@ will assume it exists."
              (buffer-file-name "_")
              (,prompt-args-sym nil))
          (cl-letf (((symbol-function 'executable-find)
-                    (lambda (name) (unless (string-equal
-                                            name "a-missing-executable.exe")
-                                     (format "/totally-mock-bin/%s" name))))
+                    (lambda (name &optional remote)
+                      (unless (string-equal
+                               name "a-missing-executable.exe")
+                        (format "/totally-mock-bin/%s" name))))
                    ((symbol-function 'read-shell-command)
                     (lambda (&rest args) (setq ,prompt-args-sym args) "")))
            (cl-destructuring-bind

--- a/eglot-tests.el
+++ b/eglot-tests.el
@@ -1106,12 +1106,12 @@ will assume it exists."
   (skip-unless (or (>= emacs-major-version 27) (executable-find "pyls")))
   ;; Set up a loopback TRAMP method that’s just a shell so the remote
   ;; host is really just the local host.
-  (let ((tramp-methods '(("loopback"
+  (let ((tramp-remote-path (cons 'tramp-own-remote-path tramp-remote-path))
+	(tramp-methods '(("loopback"
                           (tramp-login-program "/bin/sh")
-                          (tramp-login-args ())
                           (tramp-remote-shell "/bin/sh")
                           (tramp-remote-shell-login ("-l"))
-                          (tramp-remote-shell-args ("-i" "-c")))))
+                          (tramp-remote-shell-args ("-c")))))
         (temporary-file-directory (concat "/loopback::"
                                           temporary-file-directory)))
     ;; With ‘temporary-file-directory’ bound to the ‘loopback’ TRAMP

--- a/eglot.el
+++ b/eglot.el
@@ -927,7 +927,7 @@ This docstring appeases checkdoc, that's all."
                       (let ((default-directory default-directory))
                         (make-process
                          :name readable-name
-                         :command contact
+                         :command (eglot--cmd contact)
                          :connection-type 'pipe
                          :coding 'utf-8-emacs-unix
                          :noquery t


### PR DESCRIPTION
This patch adds TRAMP support to eglot (fixes #84)

I have seen https://github.com/joaotavora/eglot/pull/463 but decided to have another go at it. Some differences include:

  * This patchset includes a test for TRAMP functionality (which doesn't require passwordless ssh to a remote host!)
  * I've copied in Emacs 27.1's `executable-find` to be used on older Emacsen. 27.1 and later will use the native definition.
  * I have not included any special instructions for TRAMP. I do not believe they are necessary. Things work as expected (at least as I expect them to: you define a custom path, it'll be used on the remote. If you don't, it uses your PATH).
  * I have made `server` a mandatory argument to `eglot--uri-to-path`, because I feel it's less error-prone than having a default. Instead, I've passed in the default where necessary.

The one thing I'm not super-keen on in this patch is the use of `stty` when creating the process for the LSP. I don't know any other way to do it, though, and it seems to be how it's done from what I could dig up. It does feel like a bug in Emacs itself, though, that it should be necessary.