### PR TITLE
Fix #638: Convert colon to hex in URI

### DIFF
--- a/eglot-tests.el
+++ b/eglot-tests.el
@@ -1118,6 +1118,11 @@ will assume it exists."
     ;; method, fixtures will be automatically made “remote".
     (eglot-tests--auto-detect-running-server-1)))
 
+(ert-deftest eglot--path-to-uri-windows ()
+  (should (string-prefix-p "file:///" (eglot--path-to-uri "c:/Users/Foo/bar.lisp")))
+  (should (string-suffix-p "c%3A/Users/Foo/bar.lisp" (eglot--path-to-uri "c:/Users/Foo/bar.lisp")))
+  (should-not (string-suffix-p "c:/Users/Foo/bar.lisp" (eglot--path-to-uri "c:/Users/Foo/bar.lisp"))))
+
 (provide 'eglot-tests)
 ;;; eglot-tests.el ends here
 

--- a/eglot.el
+++ b/eglot.el
@@ -1190,13 +1190,19 @@ If optional MARKER, return a marker instead"
           (funcall eglot-move-to-column-function col)))
       (if marker (copy-marker (point-marker)) (point)))))
 
+(defconst eglot--uri-path-allowed-chars
+  (let ((vec (copy-sequence url-host-allowed-chars)))
+    (aset vec ?/ t)
+    vec)
+  "Allowed-character byte mask for the path segment of a URI.")
+
 (defun eglot--path-to-uri (path)
   "URIfy PATH."
-  (url-hexify-string
-   (concat "file://" (if (eq system-type 'windows-nt) "/")
+  (concat "file://" (if (eq system-type 'windows-nt) "/")
+          (url-hexify-string
            ;; Again watch out for trampy paths.
-           (directory-file-name (file-local-name (file-truename path))))
-   url-path-allowed-chars))
+           (directory-file-name (file-local-name (file-truename path))) 
+           eglot--uri-path-allowed-chars)))
 
 (defun eglot--uri-to-path (uri)
   "Convert URI to file path, helped by `eglot--current-server'."


### PR DESCRIPTION
It looks like we need to convert the directory colon to a hex value, and the current implementation doesn't do that. 

On close examination on both `lsp-mode` and `vscode`  I see that all uris are on the form

`file:///c%3A/Users/foo/bar`, not `file:///c:/Users/foo/bar`

This commit addresses that by creating the new `defconst` and passing it on to hexify.

This was a convoluted bug to fix - suddenly flymake behaves! 😄 