### PR TITLE
Add project-wide diagnostics

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1865,50 +1865,50 @@ the current buffer."
   :type 'hook)
 
 (defun eglot--update-diagnostics (server uri)
-  (when-let* ((buffer (find-buffer-visiting (eglot--uri-to-path uri)))
-              (diagnostics (gethash uri (eglot--diagnostics server))))
-    (with-current-buffer buffer
-      (cl-loop
-       for diag-spec across diagnostics
-       collect (eglot--dbind ((Diagnostic) range message severity source)
-                   diag-spec
-                 (setq message (concat source ": " message))
-                 (pcase-let
-                     ((sev severity)
-                      (`(,beg . ,end) (eglot--range-region range)))
-                   ;; Fallback to `flymake-diag-region' if server
-                   ;; botched the range
-                   (when (= beg end)
-                     (if-let* ((st (plist-get range :start))
-                               (diag-region
-                                (flymake-diag-region
-                                 (current-buffer) (1+ (plist-get st :line))
-                                 (plist-get st :character))))
-                         (setq beg (car diag-region) end (cdr diag-region))
-                       (eglot--widening
-                        (goto-char (point-min))
-                        (setq beg
-                              (point-at-bol
-                               (1+ (plist-get (plist-get range :start) :line))))
-                        (setq end
-                              (point-at-eol
-                               (1+ (plist-get (plist-get range :end) :line)))))))
-                   (eglot--make-diag (current-buffer) beg end
-                                     (cond ((<= sev 1) 'eglot-error)
-                                           ((= sev 2)  'eglot-warning)
-                                           (t          'eglot-note))
-                                     message `((eglot-lsp-diag . ,diag-spec)))))
-       into diags
-       finally (when (and flymake-mode eglot--current-flymake-report-fn)
-                 (save-restriction
-                   (widen)
-                   (funcall eglot--current-flymake-report-fn diags
-                            ;; If the buffer hasn't changed since last
-                            ;; call to the report function, flymake won't
-                            ;; delete old diagnostics.  Using :region
-                            ;; keyword forces flymake to delete
-                            ;; them (github#159).
-                            :region (cons (point-min) (point-max)))))))))
+  (when-let* ((buffer (find-buffer-visiting (eglot--uri-to-path uri))))
+    (let ((diagnostics (gethash uri (eglot--diagnostics server))))
+      (with-current-buffer buffer
+        (cl-loop
+         for diag-spec across diagnostics
+         collect (eglot--dbind ((Diagnostic) range message severity source)
+                     diag-spec
+                   (setq message (concat source ": " message))
+                   (pcase-let
+                       ((sev severity)
+                        (`(,beg . ,end) (eglot--range-region range)))
+                     ;; Fallback to `flymake-diag-region' if server
+                     ;; botched the range
+                     (when (= beg end)
+                       (if-let* ((st (plist-get range :start))
+                                 (diag-region
+                                  (flymake-diag-region
+                                   (current-buffer) (1+ (plist-get st :line))
+                                   (plist-get st :character))))
+                           (setq beg (car diag-region) end (cdr diag-region))
+                         (eglot--widening
+                          (goto-char (point-min))
+                          (setq beg
+                                (point-at-bol
+                                 (1+ (plist-get (plist-get range :start) :line))))
+                          (setq end
+                                (point-at-eol
+                                 (1+ (plist-get (plist-get range :end) :line)))))))
+                     (eglot--make-diag (current-buffer) beg end
+                                       (cond ((<= sev 1) 'eglot-error)
+                                             ((= sev 2)  'eglot-warning)
+                                             (t          'eglot-note))
+                                       message `((eglot-lsp-diag . ,diag-spec)))))
+         into diags
+         finally (when (and flymake-mode eglot--current-flymake-report-fn)
+                   (save-restriction
+                     (widen)
+                     (funcall eglot--current-flymake-report-fn diags
+                              ;; If the buffer hasn't changed since last
+                              ;; call to the report function, flymake won't
+                              ;; delete old diagnostics.  Using :region
+                              ;; keyword forces flymake to delete
+                              ;; them (github#159).
+                              :region (cons (point-min) (point-max))))))))))
 
 (cl-defun eglot--register-unregister (server things how)
   "Helper for `registerCapability'.


### PR DESCRIPTION
By adding all the diagnostics received from a server to a hash-table attached to
the server, we get the opportunity to access diagnostics for the whole workspace.

I have added one interesting entry point to this,
`eglot-find-workspace-diagnostics', that gives us the possibility to jump
directly to files with the associated diagnostics type.  This commit also
addresses the possibility to run other checkers through the newly introduced
hook, something that is requested in #596.

This pr needs some tests, and I will add them through the week. However, the current implementation offers in my opinion a better flymake experience, because as you open new files, the may already have diagnostics added to them. The first update thus seems quicker.

#### Some pictures:
<img width="977" alt="image" src="https://user-images.githubusercontent.com/26711805/110251873-f5212c00-7f82-11eb-89ac-a6cf4846968f.png">

<img width="980" alt="image" src="https://user-images.githubusercontent.com/26711805/110251900-1a159f00-7f83-11eb-9bbe-983f4fa92c0e.png">

<img width="976" alt="image" src="https://user-images.githubusercontent.com/26711805/110251914-2d286f00-7f83-11eb-94de-6d9553db10ab.png">

<img width="979" alt="image" src="https://user-images.githubusercontent.com/26711805/110251922-3b768b00-7f83-11eb-9d85-c8cd9e09f5b2.png">


* eglot.el (eglot-lsp-server): Add a new slot, `diagnostics', which is a
hash-table of all the diagnostics in a workspace attached to the current
server. KEY is the URI to the file in question and its associated unmodified
response from server.

* eglot.el (eglot--unreported-diagnostics): Remove this defvar-local, since
eglot now relies on diagnostics attached to the server.

* eglot.el (eglot--mode-line-format): Add information about project-wide
diagnostics to the mode line.  It follows the convention of flymake, with the
same propertization and fontification.

* eglot.el (eglot--update-diags): Utility function to update the server instance
with the payload received from the server.  Always overwrites everything, so
that the information stored in the instance is as fresh as possible.

* eglot.el (eglot--diagnostic-files-by-severity): Returns a list of files with
diagnostics of SEV kind.  It has no duplicates, but a file could have both
warnings and errors, and thus appear in to different invokations to this
function.

* eglot.el (eglot-find-workspace-diagnostics): The bread and butter of this
commit.  It adds `completing-read' to fetch files with diagnostics of the given
kind. Successive invokations to the universal argument yields different
diagnostic types.

* eglot.el (eglot-handle-notification): Move handling of the diagnostics to an
external hook, as well as simply storing the received diagnostics. Since we now
handle diagnostics for unvisited files, we can skip that debug logging.

* eglot.el (eglot-after-diagnostics-hook): New hook for updating of diagnostics
in the current buffer.

* eglot.el (eglot--update-diagnostics): New function to handle the received
payload of diagnostics to the current buffer.  Meant to run as a hook in
`eglot-after-diagnostics-hook'.

* eglot.el (eglot-flymake-backed): Run the new hook when this function is run
the first time. Other times, just run it directly from the hook handler through
`eglot-handle-notification'.
Add project-wide diagnostics