### PR TITLE
* add eglot-shutdown-all

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 Thanks to Brian Cully for the minimalist approach.
 
 (also thanks to Felipe Lema who conducted many early experiments in
-#463)
+[#463][github#463])
 
 ##### Code action shortcuts ([#411][github#411])
 
@@ -17,6 +17,8 @@ actions directly (`eglot-code-action-inline`,
 `eglot-code-action-quickfix`).  One can create own shortcuts for code
 actions with specific a kind by calling `eglot-code-actions` from
 elisp.
+
+##### New command `eglot-shutdown-server` ([#643][github#643])
 
 # 1.7 (16/12/2020)
 
@@ -260,3 +262,4 @@ and now said bunch of references-->
 [github#481]: https://github.com/joaotavora/eglot/issues/481
 [github#494]: https://github.com/joaotavora/eglot/issues/494
 [github#637]: https://github.com/joaotavora/eglot/issues/637
+[github#643]: https://github.com/joaotavora/eglot/issues/643

--- a/README.md
+++ b/README.md
@@ -226,9 +226,11 @@ Here's a summary of available commands:
 
 - `M-x eglot`, as described above;
 
-- `M-x eglot-reconnect` reconnects to the server;
+- `M-x eglot-reconnect` reconnects to current server;
 
-- `M-x eglot-shutdown` says bye-bye to the server;
+- `M-x eglot-shutdown` says bye-bye to server of your choice;
+
+- `M-x eglot-shutdown-all` says bye-bye to every server;
 
 - `M-x eglot-rename` ask the server to rename the symbol at point;
 

--- a/eglot.el
+++ b/eglot.el
@@ -652,11 +652,12 @@ Interactively, read SERVER from the minibuffer unless there is
 only one and it's managing the current buffer.
 
 Forcefully quit it if it doesn't respond within TIMEOUT seconds.
-Don't leave this function with the server still running.
+TIMEOUT defaults to 1.5 seconds.  Don't leave this function with
+the server still running.
 
 If PRESERVE-BUFFERS is non-nil (interactively, when called with a
 prefix argument), do not kill events and output buffers of
-SERVER.  ."
+SERVER."
   (interactive (list (eglot--read-server "Shutdown which server"
                                          (eglot-current-server))
                      t nil current-prefix-arg))
@@ -669,6 +670,13 @@ SERVER.  ."
     ;; Now ask jsonrpc.el to shut down the server.
     (jsonrpc-shutdown server (not preserve-buffers))
     (unless preserve-buffers (kill-buffer (jsonrpc-events-buffer server)))))
+
+(defun eglot-shutdown-all (&optional preserve-buffers)
+  "Politely ask all language servers to quit, in order.
+PRESERVE-BUFFERS as in `eglot-shutdown', which see."
+  (interactive (list current-prefix-arg))
+  (cl-loop for ss being the hash-values of eglot--servers-by-project
+           do (cl-loop for s in ss do (eglot-shutdown s nil preserve-buffers))))
 
 (defun eglot--on-shutdown (server)
   "Called by jsonrpc.el when SERVER is already dead."


### PR DESCRIPTION
asks all servers managed by eglot to shutdown.

closes #643 ?

about
> for the PR, should we have a function shutting down all servers in the current project, or all servers period? (or both?) 

I went with shutting down all servers since that's more like what the name implies. In my use case both options would be fine, although now that I think of it there seem to be several instances of the same server because different directories of my project are being recognized as different projects (so I'm fixing that with `project.el`)