### PR TITLE
Add Zig to eglot-server-programs using zigtools/zls

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ find-library` can help you tell if that happened.
 * Nix's [rnix-lsp][rnix-lsp]
 * Godot Engine's [built-in LSP][godot]
 * Fortran's [fortls][fortls]
+* Zig's [zls][zls]
 
 I'll add to this list as I test more servers. In the meantime you can
 customize `eglot-server-programs`:
@@ -561,3 +562,4 @@ Under the hood:
 [godot]: https://godotengine.org
 [fortls]: https://github.com/hansec/fortran-language-server
 [gospb]: https://opensource.googleblog.com/2020/10/announcing-latest-google-open-source.html
+[zls]: https://github.com/zigtools/zls

--- a/eglot.el
+++ b/eglot.el
@@ -125,7 +125,8 @@ language-server/bin/php-language-server.php"))
                                 (erlang-mode . ("erlang_ls" "--transport" "stdio"))
                                 (nix-mode . ("rnix-lsp"))
                                 (gdscript-mode . ("localhost" 6008))
-                                (f90-mode . ("fortls")))
+                                (f90-mode . ("fortls"))
+                                (zig-mode . ("zls")))
   "How the command `eglot' guesses the server to start.
 An association list of (MAJOR-MODE . CONTACT) pairs.  MAJOR-MODE
 is a mode symbol, or a list of mode symbols.  The associated


### PR DESCRIPTION
No other configuration was needed for formatting or completion on '.'
which was rather surprising. I have not extensively tested zls, though
all immediately expected functionality appears to work well.