### PR TITLE
Document how to set the languageId

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ customize `eglot-server-programs`:
 
 ```lisp
 (add-to-list 'eglot-server-programs '(foo-mode . ("foo-language-server" "--args")))
+;; If the server expects "bar" as the languageId, then you can specify this as:
+;; (put 'foo-mode 'eglot-language-id "bar")
 ```
 
 Let me know how well it works and we can add it to the list.  


### PR DESCRIPTION
It seems this relatively new feature hasn't been documented.  This PR mentions the feature in the README.  

However, skimming through #624, I tend to agree that a `(put 'foo-mode 'eglot-language-id "bar")` line does not belong to foo.el.  There might be a foo-1-server expecting `foo` as languageId and a foo-2-server that expects `bar`.  Ideally (I think) the syntax of variable `eglot-server-programs` should be extended.  We could perhaps define a :languageId key similarly to the existing :autoport key.  

Nevertheless, this PR documents the status quo. 

* README.md (Connecting to a server): Provide an example on setting a
major-mode specific languageId.