### PR TITLE
Switch default langserver for OCaml to ocamllsp

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -105,7 +105,7 @@
 language-server/bin/php-language-server.php"))
                                 ((c++-mode c-mode) . ("ccls"))
                                 ((caml-mode tuareg-mode reason-mode)
-                                 . ("ocaml-language-server" "--stdio"))
+                                 . ("ocamllsp"))
                                 (ruby-mode
                                  . ("solargraph" "socket" "--port" :autoport))
                                 (haskell-mode


### PR DESCRIPTION
The repo for ocaml-language-server has been archived and inactive for quite some time:

   https://github.com/ocaml-lsp/ocaml-language-server

Meanwhile, ocaml-lsp is the generally-preferred option, and is actively maintained in the ocaml org itself:

   https://github.com/ocaml/ocaml-lsp/