### PR TITLE
Fix path/URI usage when using TRAMP from an MS Windows client

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -981,8 +981,8 @@ This docstring appeases checkdoc, that's all."
                               (emacs-pid))
                             ;; Maybe turn trampy `/ssh:foo@bar:/path/to/baz.py'
                             ;; into `/path/to/baz.py', so LSP groks it.
-                            :rootPath (expand-file-name
-                                       (file-local-name default-directory))
+                            :rootPath (file-local-name
+                                       (expand-file-name default-directory))
                             :rootUri (eglot--path-to-uri default-directory)
                             :initializationOptions (eglot-initialization-options
                                                     server)
@@ -1209,24 +1209,31 @@ If optional MARKER, return a marker instead"
 
 (defun eglot--path-to-uri (path)
   "URIfy PATH."
-  (concat "file://" (if (eq system-type 'windows-nt) "/")
-          (url-hexify-string
-           ;; Again watch out for trampy paths.
-           (directory-file-name (file-local-name (file-truename path))) 
-           eglot--uri-path-allowed-chars)))
+  (let ((truepath (file-truename path)))
+    (concat "file://"
+            ;; Add a leading "/" for local MS Windows-style paths.
+            (if (and (eq system-type 'windows-nt)
+                     (not (file-remote-p truepath)))
+                "/")
+            (url-hexify-string
+             ;; Again watch out for trampy paths.
+             (directory-file-name (file-local-name truepath))
+             eglot--uri-path-allowed-chars))))
 
 (defun eglot--uri-to-path (uri)
   "Convert URI to file path, helped by `eglot--current-server'."
   (when (keywordp uri) (setq uri (substring (symbol-name uri) 1)))
-  (let* ((retval (url-filename (url-generic-parse-url (url-unhex-string uri))))
-         (normalized (if (and (eq system-type 'windows-nt)
-                              (cl-plusp (length retval)))
-                         (substring retval 1)
-                       retval))
-         (server (eglot-current-server))
+  (let* ((server (eglot-current-server))
          (remote-prefix (and server
                              (file-remote-p
-                              (project-root (eglot--project server))))))
+                              (project-root (eglot--project server)))))
+         (retval (url-filename (url-generic-parse-url (url-unhex-string uri))))
+         ;; Remove the leading "/" for local MS Windows-style paths.
+         (normalized (if (and (not remote-prefix)
+                              (eq system-type 'windows-nt)
+                              (cl-plusp (length retval)))
+                         (substring retval 1)
+                       retval)))
     (concat remote-prefix normalized)))
 
 (defun eglot--snippet-expansion-fn ()


### PR DESCRIPTION
Hopefully the below is enough information to fully-explain this issue. If there's anything else you think I should add (e.g. following the full issue-reporting template, or writing tests), just let me know.

---

I mentioned this in https://github.com/joaotavora/eglot/discussions/675, and now that I've submitted my FSF copyright assignment, I think it's probably safe to just file a PR for the fix. As mentioned in the discussion, there are two issues I came across when attempting to use eglot over TRAMP from MS Windows. This snippet from the event log will help explain the problem:

```
[client-request] (id:1) Thu Apr 22 19:12:57 2021:
(:jsonrpc "2.0" :id 1 :method "initialize" :params
          (:processId nil :rootPath "e:/home/jim/test/" :rootUri "file:////home/jim/test" :initializationOptions #s(hash-table size 65 test eql rehash-size 1.5 rehash-threshold 0.8125 data
```

First, `:rootPath` is `e:/home/jim/test/`, even though that's a path on the *remote* system (running Linux). I didn't encounter any broken behavior due to this, but that's probably dependent on the LSP server being used (I was testing with `clangd`). This problem is caused by calling `expand-file-name` after `file-local-name` in `eglot--connect`; I think it should be the other way around.

Second, `:rootUri` is `file:////home/jim/test`. Note that there are **4** slashes instead of 3. This is because `eglot--path-to-uri` adds an extra leading `/` on MS Windows. This makes sure that `c:/path/to/file.txt` becomes `file:///c:/path/to/file.txt`. However, when the path is a *remote* path, this doesn't work right, and produces the erroneous string above with 4 slashes. (I think the local part of a TRAMP path should always start with a `/`, but if you want to be extra-safe, maybe we should account for local parts starting with something else.)

For files *within* the current project, this actually ends up working (probably partly because `clangd` plays nice with us), because `eglot--uri-to-path` strips the superfluous slash. However, when a path is *outside* the current project, the LSP server returns an ordinary `file:` URI with 3 leading slashes, e.g. `file:///path/to/header.h`. This then gets translated into `/sshx:server:path/to/header.h` (note the lack of a `/` before `path`), which is wrong.

In practice, this is a problem for things like `xref-find-definitions`. If you have a source file like so:

```
#include <vector>

int main() {
  std::vector<int> v;
}
```

And put the point over `vector` and press `M-.`, it fails to load the correct (remote) file because the TRAMP path is wrong.