### PR TITLE
Avoid positional args in define-minor-mode to fix warning in Emacs 28

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1440,7 +1440,9 @@ Use `eglot-managed-p' to determine if current buffer is managed.")
 
 (define-minor-mode eglot--managed-mode
   "Mode for source buffers managed by some EGLOT project."
-  nil nil eglot-mode-map
+  :init-value nil
+  :lighter nil
+  :keymap eglot-mode-map
   (cond
    (eglot--managed-mode
     (add-hook 'after-change-functions 'eglot--after-change nil t)

--- a/eglot.el
+++ b/eglot.el
@@ -1440,9 +1440,7 @@ Use `eglot-managed-p' to determine if current buffer is managed.")
 
 (define-minor-mode eglot--managed-mode
   "Mode for source buffers managed by some EGLOT project."
-  :init-value nil
-  :lighter nil
-  :keymap eglot-mode-map
+  :init-value nil :lighter nil :keymap eglot-mode-map
   (cond
    (eglot--managed-mode
     (add-hook 'after-change-functions 'eglot--after-change nil t)


### PR DESCRIPTION
Trivial fix for a recently-added byte compilation warning.