### PR TITLE
add lua-lsp for lua-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ find-library` can help you tell if that happened.
 * Zig's [zls][zls]
 * FSharp's [fsharp-mode][fsharp-mode] (Needs to `(require 'eglot-fsharp)` first)
 * YAML's [yaml-language-server][yaml-language-server]
+* Lua's [lua-lsp][lua-lsp]
 
 I'll add to this list as I test more servers. In the meantime you can
 customize `eglot-server-programs`:
@@ -588,3 +589,4 @@ Under the hood:
 [gospb]: https://opensource.googleblog.com/2020/10/announcing-latest-google-open-source.html
 [zls]: https://github.com/zigtools/zls
 [fsharp-mode]: https://github.com/fsharp/emacs-fsharp-mode
+[lua-lsp]: https://github.com/Alloyed/lua-lsp

--- a/eglot.el
+++ b/eglot.el
@@ -176,6 +176,7 @@ language-server/bin/php-language-server.php"))
                                 (nix-mode . ("rnix-lsp"))
                                 (gdscript-mode . ("localhost" 6008))
                                 ((fortran-mode f90-mode) . ("fortls"))
+                                (lua-mode . ("lua-lsp"))
                                 (zig-mode . ("zls")))
   "How the command `eglot' guesses the server to start.
 An association list of (MAJOR-MODE . CONTACT) pairs.  MAJOR-MODE


### PR DESCRIPTION
Hello,

trivial patch to add `lua-lsp` for lua-mode.  I've just started to play with lua, but with this plus a `.luacompleterc` file I'm able to get completions for both built-in functions and external modules.

Cheers

edit: I wasn't sure what's the correct order is, so I added lua as last entry.