### PR TITLE
All completions

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2358,10 +2358,10 @@ is not active."
          (cond
           ((eq action 'metadata) metadata)               ; metadata
           ((eq action 'lambda)                           ; test-completion
-           (test-completion probe (funcall proxies)))
+           (test-completion probe (funcall proxies) pred))
           ((eq (car-safe action) 'boundaries) nil)       ; boundaries
           ((null action)                                 ; try-completion
-           (try-completion probe (funcall proxies)))
+           (try-completion probe (funcall proxies) pred))
           ((eq action t)                                 ; all-completions
 	   (all-completions "" (funcall proxies)
 			    (lambda (cand)

--- a/eglot.el
+++ b/eglot.el
@@ -2363,14 +2363,12 @@ is not active."
           ((null action)                                 ; try-completion
            (try-completion probe (funcall proxies)))
           ((eq action t)                                 ; all-completions
-           (cl-remove-if-not
-            (lambda (proxy)
-              (let* ((item (get-text-property 0 'eglot--lsp-item proxy))
-                     (filterText (plist-get item :filterText)))
-                (and (or (null pred) (funcall pred proxy))
-                     (string-prefix-p
-                      probe (or filterText proxy) completion-ignore-case))))
-            (funcall proxies)))))
+	   (all-completions "" (funcall proxies)
+			    (lambda (cand)
+			      (let* ((item (get-text-property 0 'eglot--lsp-item cand))
+				     (text (or (plist-get item :filterText) cand)))
+				(and (string-prefix-p probe text completion-ignore-case)
+				     (or (not pred) (funcall pred cand)))))))))
        :annotation-function
        (lambda (proxy)
          (eglot--dbind ((CompletionItem) detail kind)


### PR DESCRIPTION
This uses all-completions to enable searching of candidates with `completion-regexp-list`, which CAPF collection functions are required to do (from elisp/basic completion info):

>  In addition, to be acceptable, a completion must also match all the regular expressions in ‘completion-regexp-list’.  (Unless  COLLECTION is a function, in which case that function has to handle ‘completion-regexp-list’ itself.)

It also ensures any predicate passed to the collection function is forwarded to try/test-completion.