### PR TITLE
Invalidate the proxy cache when probe text is altered

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2306,6 +2306,7 @@ is not active."
            (metadata `(metadata (category . eglot)
                                 (display-sort-function . ,sort-completions)))
            resp items (cached-proxies :none)
+	   (last-probe nil)
            (proxies
             (lambda ()
               (if (listp cached-proxies) cached-proxies
@@ -2355,6 +2356,12 @@ is not active."
        (or (car bounds) (point))
        (or (cdr bounds) (point))
        (lambda (probe pred action)
+	 (unless (string-empty-p probe)
+	   (if last-probe
+	       (unless (string-prefix-p last-probe probe)
+		 (setq cached-proxies :none
+		       last-probe probe))
+	     (setq last-probe probe)))
          (cond
           ((eq action 'metadata) metadata)               ; metadata
           ((eq action 'lambda)                           ; test-completion


### PR DESCRIPTION
This concerns the cache which eglot's collection table maintains as a lexical closure.  Some completion UI's, like company, regenerate the collection table on new input.  Others, like corfu, expect the backend to do the right thing based on the current text in the buffer, and keep the collection table alive during an entire completion process.  Currently UI's with the latter behavior produce unexpected results when the original probe string is altered (see minad/corfu#59).

With this simple fix, if the initial "probe" text is ever altered or partially deleted, eglot will invalidate its cache and re-contact the LSP server.