### PR TITLE
Adds mint language server

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ find-library` can help you tell if that happened.
 * C/C++'s [clangd][clangd] or [ccls][ccls]
 * Haskell's [haskell-language-server][haskell-language-server]
 * Elm's [elm-language-server][elm-language-server]
+* Mint's [mint-ls][mint-ls]
 * Kotlin's [kotlin-language-server][kotlin-language-server]
 * Go's [gopls][gopls]
 * Ocaml's [ocaml-lsp][ocaml-lsp]
@@ -565,6 +566,7 @@ Under the hood:
 [windows-subprocess-hang]: https://www.gnu.org/software/emacs/manual/html_node/efaq-w32/Subprocess-hang.html
 [haskell-language-server]: https://github.com/haskell/haskell-language-server
 [elm-language-server]: https://github.com/elm-tooling/elm-language-server
+[mint-ls]: https://www.mint-lang.com/
 [kotlin-language-server]: https://github.com/fwcd/KotlinLanguageServer
 [gopls]: https://github.com/golang/tools/tree/master/gopls
 [eclipse-jdt]: https://github.com/eclipse/eclipse.jdt.ls

--- a/eglot.el
+++ b/eglot.el
@@ -159,6 +159,7 @@ language-server/bin/php-language-server.php"))
                                 (haskell-mode
                                  . ("haskell-language-server-wrapper" "--lsp"))
                                 (elm-mode . ("elm-language-server"))
+                                (mint-mode . ("mint" "ls"))
                                 (kotlin-mode . ("kotlin-language-server"))
                                 (go-mode . ("gopls"))
                                 ((R-mode ess-r-mode) . ("R" "--slave" "-e"


### PR DESCRIPTION
Hi, this is a WIP. I wanted to open the pull request in case anyone would like to help out with testing this language server.

`mint ls` was merged into [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/pull/1136) recently.

I thought it would be nice to add it to eglot also :)

Mint's language server is built into the cli interface of [mint](https://github.com/mint-lang/mint/tree/master/src/lsp) [itself](https://github.com/mint-lang/mint/tree/master/src/ls).

Here are the features that are currently supported by the mint language server:

https://github.com/mint-lang/mint/blob/master/src/ls/README.md

Let me know if you would like me to debug anything in particular. 

I'll report back once I fully test all the features that are/are not working.

![mint-loves-eglot](https://user-images.githubusercontent.com/47760695/135783074-e8bbfa89-7ddf-4a2c-8510-5286673a4df5.png)
