### PR TITLE
Support the which-func package, i.e. which-function-mode

### DIFF
--- a/eglot-tests.el
+++ b/eglot-tests.el
@@ -523,6 +523,22 @@ Pass TIMEOUT to `eglot--with-timeout'."
         (forward-line -1)
         (should (looking-at "Complete, but not unique"))))))
 
+(ert-deftest basic-which-func ()
+  "Test basic which-func functionality in a python LSP"
+  (skip-unless (executable-find "pyls"))
+  (eglot--with-fixture
+      `(("project" . (("something.py" . "def foo(): pass\ndef bar(): foo()\n"))))
+    (with-current-buffer
+        (eglot--find-file-noselect "project/something.py")
+      (should (eglot--tests-connect))
+      (which-function-mode t)
+      (goto-char (point-min))           ; def foo():
+      (should (string= (which-function) "foo"))
+      (goto-char (point-max))           ; end of file
+      (should (null (which-function)))
+      (forward-line -1)                 ; def bar():
+      (should (string= (which-function) "bar")))))
+
 (ert-deftest basic-xref ()
   "Test basic xref functionality in a python LSP"
   (skip-unless (executable-find "pyls"))


### PR DESCRIPTION
which-func assumes that imenu is enabled and determines which function your current point is in using imenu--index-alist.

However, it doesn’t understand special elements in imenu--index-alist so those entries must be handled by a hook installed in
which-func-functions.

* eglot.el (eglot-which-func): Hook to determine the function which your current point is in, based on Eglot’s special Imenu element.

* eglot.el (eglot--managed-mode): Add and remove the eglot-which-func hook in which-func-functions.

* eglot-tests.el (basic-which-func): Test which-function-mode.