### PR TITLE
Refactor Imenu support to store textDocument/documentSymbol information in overlays

### DIFF
--- a/eglot-tests.el
+++ b/eglot-tests.el
@@ -523,6 +523,20 @@ Pass TIMEOUT to `eglot--with-timeout'."
         (forward-line -1)
         (should (looking-at "Complete, but not unique"))))))
 
+(ert-deftest basic-imenu ()
+  "Test basic imenu functionality in a python LSP"
+  (skip-unless (executable-find "pyls"))
+  (eglot--with-fixture
+   `(("project" . (("something.py" . "def foo(): pass\ndef bar(): foo()\n"))))
+   (with-current-buffer
+       (eglot--find-file-noselect "project/something.py")
+     (should (eglot--tests-connect))
+     (should (imenu--make-index-alist))
+     (imenu (assoc "foo" (assoc "Function" imenu--index-alist)))
+     (should (looking-at "def foo():"))
+     (imenu (assoc "bar" (assoc "Function" imenu--index-alist)))
+     (should (looking-at "def bar():")))))
+
 (ert-deftest basic-xref ()
   "Test basic xref functionality in a python LSP"
   (skip-unless (executable-find "pyls"))


### PR DESCRIPTION
`eglot-imenu` used to build `imenu--index-alist` with special elements, of the form `(INDEX-NAME POSITION FUNCTION ARGUMENTS...)` which is not a great API. Most packages that integrate with Imenu cannot work with these elements, and expect the simple element of `(INDEX-NAME . POSITION)`. See related issues: #535, #536, #547, #621, #758.

This pull request is designed to tackle this problem by:
1. Storing the result of `textDocument/documentSymbol` JSON-RPC calls in [overlays](https://www.gnu.org/software/emacs/manual/html_node/elisp/Overlays.html), both in raw and parsed forms.
2. Building `imenu--index-alist` from these overlays with entirely simple elements.
3. Registring a `which-func-functions` hook to read the current function/class/named-scope from the best overlay.