### PR TITLE
Mark eglot completions as non-exclusive

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2415,6 +2415,7 @@ is not active."
             (regexp-opt
              (cl-coerce (cl-getf completion-capability :triggerCharacters) 'list))
             (line-beginning-position))))
+       :exclusive 'no
        :exit-function
        (lambda (proxy status)
          (when (eq status 'finished)


### PR DESCRIPTION
Add a property to the eglot-completion-at-point results marking it as non-exclusive. This will allow completion to fall back to other less precise completion backends if eglot returns no results (e.g. dabbrev)