### PR TITLE
Fix #769: support autoImportText from pyright language server

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2394,6 +2394,13 @@ is not active."
                      (kind (alist-get (plist-get lsp-item :kind)
                                       eglot--kind-names)))
            (intern (downcase kind))))
+       :company-docsig
+       ;; FIXME: autoImportText is specific to the pyright language server
+       (lambda (proxy)
+         (when-let* ((lsp-comp (get-text-property 0 'eglot--lsp-item proxy))
+                     (data (plist-get (funcall resolve-maybe lsp-comp) :data))
+                     (import-text (plist-get data :autoImportText)))
+           import-text))
        :company-doc-buffer
        (lambda (proxy)
          (let* ((documentation


### PR DESCRIPTION
See #769. I guess this information can also be shown via the annotation function. I tested it, and found this way more elegant.