### PR TITLE
Fix "GNU ELPA" typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ way:
 
 # _1-2-3_
 
-Install from [ELPA][gnuelpa] or [MELPA][melpa].  Just type `M-x
+Install from [GNU ELPA][gnuelpa] or [MELPA][melpa].  Just type `M-x
 package-install RET eglot RET` into Emacs 26.1+.
 
 Now find some source file, any source file, and type `M-x eglot`.


### PR DESCRIPTION
This fixes a typo in README.md.

The repository is actually called "GNU ELPA", while the protocol itself is called ELPA.