### PR TITLE
Add GNU ELPA badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/joaotavora/eglot.png?branch=master)](https://travis-ci.org/joaotavora/eglot)
+[![GNU ELPA](https://elpa.gnu.org/packages/eglot.svg)](https://elpa.gnu.org/packages/eglot.html)
 [![MELPA](http://melpa.org/packages/eglot-badge.svg)](http://melpa.org/#/eglot)
 
 # M-x Eglot


### PR DESCRIPTION
GNU ELPA has badges now. This commit adds one to README.md.

You can see the badge here:
https://elpa.gnu.org/packages/eglot.svg

Thanks!