### PR TITLE
Add up-to-date server executables for HTML/CSS/JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,9 +582,9 @@ Under the hood:
 [dart_language_server]: https://github.com/natebosch/dart_language_server
 [elixir-ls]: https://github.com/elixir-lsp/elixir-ls
 [erlang_ls]: https://github.com/erlang-ls/erlang_ls
-[html-languageserver]: https://github.com/Microsoft/vscode/tree/master/extensions/html-language-features/server
-[css-languageserver]: https://github.com/Microsoft/vscode/tree/master/extensions/css-language-features/server
-[vscode-json-languageserver]: https://www.npmjs.com/package/vscode-json-languageserver
+[html-languageserver]: https://github.com/hrsh7th/vscode-langservers-extracted
+[css-languageserver]: https://github.com/hrsh7th/vscode-langservers-extracted
+[vscode-json-languageserver]: https://github.com/hrsh7th/vscode-langservers-extracted
 [docker-langserver]: https://github.com/rcjsuen/dockerfile-language-server-nodejs
 [cmake-language-server]: https://github.com/regen100/cmake-language-server
 [vim-language-server]: https://github.com/iamcco/vim-language-server

--- a/eglot.el
+++ b/eglot.el
@@ -180,9 +180,9 @@ language-server/bin/php-language-server.php"))
                                 ((fortran-mode f90-mode) . ("fortls"))
                                 (lua-mode . ("lua-lsp"))
                                 (zig-mode . ("zls"))
-                                (css-mode "css-languageserver" "--stdio")
-                                (html-mode "html-languageserver" "--stdio")
-                                (json-mode "json-languageserver" "--stdio")
+                                (css-mode . ,(eglot-alternatives '(("vscode-css-language-server" "--stdio") ("css-languageserver" "--stdio"))))
+                                (html-mode . ,(eglot-alternatives '(("vscode-html-language-server" "--stdio") ("html-languageserver" "--stdio"))))
+                                (json-mode . ,(eglot-alternatives '(("vscode-json-language-server" "--stdio") ("json-languageserver" "--stdio"))))
                                 (dockerfile-mode . ("docker-langserver" "--stdio")))
   "How the command `eglot' guesses the server to start.
 An association list of (MAJOR-MODE . CONTACT) pairs.  MAJOR-MODE

--- a/eglot.el
+++ b/eglot.el
@@ -112,7 +112,7 @@ chosen (interactively or automatically)."
                                collect (if (listp a) a (list a))))
            (err (lambda ()
                   (error "None of '%s' are valid executables"
-                         (mapconcat #'identity alternatives ", ")))))
+                         (mapconcat #'car listified ", ")))))
       (cond (interactive
              (let* ((augmented (mapcar (lambda (a)
                                          (let ((found (eglot--executable-find


### PR DESCRIPTION
* README.md: Advertise updated executables.
* eglot.el (eglot-server-programs): Prioritize the alternatives.

The {html,css,json}-languageserver executables that are distributed
outside VS Code are not regularly updated by Microsoft; any relevant
updates to the VS Code source tree reach VS Code users without the
need for VS Code developers to go out of their way to publish new
versions of the executables. Consequently, users of other editors who
have been using the server executables from the most obvious NPM
installation are likely using stale versions.

GH hrsh7th, a Vim user, created an NPM package with updated versions
of these executables taken straight from VS Code's source tree. We
therefore prefer to direct users to this other repo, which contains
the appropriate NPM installation instructions, in the README.

The second commit forces `eglot-alternatives` to work with the
listified form, allowing presumed executables provided as
(EXECUTABLE &rest ARGS...)  to be displayed in the error.

cc @skangas