### PR TITLE
Per #784: Add tooltip describing pending requests

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1720,7 +1720,9 @@ Uses THING, FACE, DEFS and PREPEND."
              `("/" ,(eglot--mode-line-props
                      (format "%d" pending) 'warning
                      '((mouse-3 eglot-forget-pending-continuations
-                                "forget pending continuations"))))))))))
+                                "forget pending continuations"))
+                     "Number of outgoing, \
+still unanswered LSP requests to the server"))))))))
 
 (add-to-list 'mode-line-misc-info
              `(eglot--managed-mode (" [" eglot--mode-line-format "] ")))


### PR DESCRIPTION
@skangas asked me to install this change.  I'd rather send it as a pull request, because I'm not able to end up in a situation with pending requests, therefore I haven't tested this PR.

----
* eglot.el (eglot--mode-line-format): Add tooltip to `pending'.