### PR TITLE
Fix #768: Mention lack of support for Diagnostic.codeDescription

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -351,7 +351,7 @@ This can be useful when using docker to run a language server.")
                              :sortText :filterText :insertText :insertTextFormat
                              :textEdit :additionalTextEdits :commitCharacters
                              :command :data))
-      (Diagnostic (:range :message) (:severity :code :source :relatedInformation))
+      (Diagnostic (:range :message) (:severity :code :source :relatedInformation :codeDescription))
       (DocumentHighlight (:range) (:kind))
       (FileSystemWatcher (:globPattern) (:kind))
       (Hover (:contents) (:range))
@@ -689,7 +689,11 @@ treated as in `eglot-dbind'."
              :formatting         `(:dynamicRegistration :json-false)
              :rangeFormatting    `(:dynamicRegistration :json-false)
              :rename             `(:dynamicRegistration :json-false)
-             :publishDiagnostics `(:relatedInformation :json-false))
+             :publishDiagnostics (list :relatedInformation :json-false
+                                       ;; TODO: We can support :codeDescription after
+                                       ;; adding an appropriate UI to
+                                       ;; Flymake.
+                                       :codeDescriptionSupport :json-false))
             :experimental eglot--{})))
 
 (defclass eglot-lsp-server (jsonrpc-process-connection)


### PR DESCRIPTION
A codeDescription property is, at the time of writing, an object with
an href property (of type URI, or a string), denoting a "URI to open
with more information about the diagnostic error".

It's not obvious how best to put this into a Flymake diagostic
aside from simply appending it to the diagnostic message, so we'll
worry about it some other time.

Fixes #768.