### PR TITLE
Add support for optional CompletionItem.tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ ELPADEPS ?=--eval '(setq package-user-dir (expand-file-name "elpa-eglot-test" te
            --eval '(install-latest (quote jsonrpc))'            \
            --eval '(install-latest (quote project))'            \
            --eval '(install-latest (quote xref))'               \
+           --eval '(install-latest (quote seq))'                \
            --eval '(install-latest (quote eldoc))'              \
            --eval '(unintern                                    \
                      (quote eldoc-documentation-function))'     \

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,11 @@ diagnostics from buffers other than the currently visited one.  The
 command `M-x flymake-show-project-diagnostics` will now show all
 diagnostics relevant to a workspace.
 
+##### Support optional completion tags ([#797][github#797])
+A [completion-item tag][completiontag] can be used to tell the editor
+how to render a completion.  Presently, one kind of tag exists,
+denoting its corresponding completion as obsolete.
+
 ##### Support optional diagnostic tags ([#794][github#794])
 A [diagnostic tag][diagnostictag] can indicate either "unused or
 unnecessary code" or "deprecated or obsolete code".  Following the
@@ -240,6 +245,7 @@ TCP connection finds a listening server.
 ##### Assorted bugfixes
 
 [diagnostictag]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#diagnosticTag
+[completiontag]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#completionItemTag
 <!--- Now a bunch of references that I auto-generate with
 
 (cl-loop


### PR DESCRIPTION
* eglot.el (eglot--lsp-interface-alist): Add optional CompletionItem.tags.
(eglot-completion-at-point): Add :company-deprecated key and value.