### PR TITLE
Change Rust language server to rust-analyzer and drop RLS support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@ unnecessary code" or "deprecated or obsolete code".  Following the
 rendering suggestions in the protocol, we fade out unnecessary code
 and strike-through deprecated code.
 
+##### The Rust language server is now rust-analyzer by default ([#803][github#803])
+Eglot will now prefer starting "rust-analazyer" to "rls" when it is
+available.  The special support code for RLS has been removed.
+
 ##### New servers have been added to `eglot-server-programs`
 - racket-langserver ([#694][github#694])
 
@@ -327,3 +331,4 @@ and now said bunch of references-->
 [github#769]: https://github.com/joaotavora/eglot/issues/769
 [github#787]: https://github.com/joaotavora/eglot/issues/787
 [github#794]: https://github.com/joaotavora/eglot/issues/794
+[github#803]: https://github.com/joaotavora/eglot/issues/803

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ find-library` can help you tell if that happened.
 * R's [languageserver][r-languageserver]
 * Racket's [racket-langserver][racket-langserver]
 * Ruby's [solargraph][solargraph]
-* Rust's [rls][rls]
+* Rust's [rust-analyzer][rust-analyzer]
 * Scala's [metals][metals]
 * TeX/LaTeX's [Digestif][digestif]
 * VimScript's [vim-language-server][vim-language-server]
@@ -467,7 +467,7 @@ User-visible differences:
   connection name;
 - Pretty interactive mode-line section for live tracking of server
   communication;
-- Automatically restarts frequently crashing servers (like RLS);
+- Automatically restarts frequently crashing servers;
 - Slow-to-start servers start asynchronously in the background;
 - Server-initiated edits are confirmed with the user;
 - Diagnostics work out-of-the-box (no `flycheck.el` needed);
@@ -517,7 +517,7 @@ Under the hood:
 [r-languageserver]: https://cran.r-project.org/package=languageserver
 [racket-langserver]: https://github.com/jeapostrophe/racket-langserver
 [solargraph]: https://github.com/castwide/solargraph
-[rls]: https://github.com/rust-lang-nursery/rls
+[rust-analyzer]: https://github.com/rust-analyzer/rust-analyzer
 [metals]: https://scalameta.org/metals/
 [digestif]: https://github.com/astoff/digestif
 [vim-language-server]: https://github.com/iamcco/vim-language-server

--- a/eglot-tests.el
+++ b/eglot-tests.el
@@ -371,9 +371,9 @@ Pass TIMEOUT to `eglot--with-timeout'."
           (while (process-live-p proc) (accept-process-output nil 0.5)))
         (should (not (eglot-current-server)))))))
 
-(ert-deftest rls-watches-files ()
-  "Start RLS server.  Notify it when a critical file changes."
-  (skip-unless (executable-find "rls"))
+(ert-deftest rust-analyzer-watches-files ()
+  "Start rust-analyzer.  Notify it when a critical file changes."
+  (skip-unless (executable-find "rust-analyzer"))
   (skip-unless (executable-find "cargo"))
   (let ((eglot-autoreconnect 1))
     (eglot--with-fixture
@@ -467,9 +467,9 @@ Pass TIMEOUT to `eglot--with-timeout'."
    do (sit-for 0.5)
    finally (error "eglot--tests-force-full-eldoc didn't deliver")))
 
-(ert-deftest rls-hover-after-edit ()
-  "Hover and highlightChanges are tricky in RLS."
-  (skip-unless (executable-find "rls"))
+(ert-deftest rust-analyzer-hover-after-edit ()
+  "Hover and highlightChanges."
+  (skip-unless (executable-find "rust-analyzer"))
   (skip-unless (executable-find "cargo"))
   (eglot--with-fixture
       '(("hover-project" .

--- a/eglot.el
+++ b/eglot.el
@@ -142,7 +142,7 @@ chosen (interactively or automatically)."
                       when probe return (cons probe args)
                       finally (funcall err)))))))
 
-(defvar eglot-server-programs `((rust-mode . (eglot-rls "rls"))
+(defvar eglot-server-programs `((rust-mode . ("rust-analyzer" "rls"))
                                 (cmake-mode . ("cmake-language-server"))
                                 (vimrc-mode . ("vim-language-server" "--stdio"))
                                 (python-mode
@@ -2983,25 +2983,6 @@ If NOERROR, return predicate, else erroring function."
 (defun eglot--glob-emit-range (arg self next)
   (when (eq ?! (aref arg 1)) (aset arg 1 ?^))
   `(,self () (re-search-forward ,(concat "\\=" arg)) (,next)))
-
-
-;;; Rust-specific
-;;;
-(defclass eglot-rls (eglot-lsp-server) () :documentation "Rustlang's RLS.")
-
-(cl-defmethod jsonrpc-connection-ready-p ((server eglot-rls) what)
-  "Except for :completion, RLS isn't ready until Indexing done."
-  (and (cl-call-next-method)
-       (or ;; RLS normally ready for this, even if building.
-        (eq :textDocument/completion what)
-        (pcase-let ((`(,_id ,what ,done ,_detail) (eglot--spinner server)))
-          (and (equal "Indexing" what) done)))))
-
-(cl-defmethod eglot-handle-notification
-  ((server eglot-rls) (_method (eql window/progress))
-   &key id done title message &allow-other-keys)
-  "Handle notification window/progress."
-  (setf (eglot--spinner server) (list id title done message)))
 
 
 ;;; eclipse-jdt-specific


### PR DESCRIPTION
As discussed in #800.

rust-analyzer is the officially blessed Language Server for Rust:
https://github.com/rust-lang/rfcs/pull/2912

Also drop the special support code for RLS.

* eglot.el (eglot-server-programs): Change rust-mode language server
from rls to rust-analyzer.
(eglot-rls, jsonrpc-connection-ready-p)
(eglot-handle-notification): Delete.
* README.md: Update references for RLS to point to rust-analyzer.