### PR TITLE
Properly check the CompletionItem.deprecated property

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2472,7 +2472,7 @@ is not active."
          (when-let ((lsp-item (get-text-property 0 'eglot--lsp-item proxy)))
            (or (seq-contains-p (plist-get lsp-item :tags)
                                1)
-               (plist-get lsp-item :deprecated))))
+               (eq t (plist-get lsp-item :deprecated)))))
        :company-docsig
        ;; FIXME: autoImportText is specific to the pyright language server
        (lambda (proxy)


### PR DESCRIPTION
* eglot.el (eglot-completion-at-point): Check the :deprecated property
is `t'.  We do this so that a :deprecated property of :json-false does
not cause a completion candidate to be incorrectly marked as deprecated.

Verified with the Elixir language server with the following file:

``` elixir
IO.puts "Hello world!"
# Try typing the following:
# H

# The above should cause two deprecated completions, HashSet and HashDict, to be offered

# Also try typing the following:
# e

# The above should cause two non-deprecated completions.
```