### PR TITLE
Send :textDocument/willSave only when supported by the server

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2144,7 +2144,8 @@ When called interactively, use the currently active server"
   "Send textDocument/willSave to server."
   (let ((server (eglot--current-server-or-lose))
         (params `(:reason 1 :textDocument ,(eglot--TextDocumentIdentifier))))
-    (jsonrpc-notify server :textDocument/willSave params)
+    (when (eglot--server-capable :textDocumentSync :willSave)
+      (jsonrpc-notify server :textDocument/willSave params))
     (when (eglot--server-capable :textDocumentSync :willSaveWaitUntil)
       (ignore-errors
         (eglot--apply-text-edits


### PR DESCRIPTION
* eglot.el (eglot--signal-textDocument/willSave): Send
:textDocument/willSave only when supported by the server.

Fixes #820, addresses part of #360.