### PR TITLE
Warn if the URI-scheme is not "file"

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1404,13 +1404,16 @@ If optional MARKER, return a marker instead"
          (remote-prefix (and server
                              (file-remote-p
                               (project-root (eglot--project server)))))
-         (retval (url-filename (url-generic-parse-url (url-unhex-string uri))))
+         (url (url-generic-parse-url (url-unhex-string uri)))
+         (retval (url-filename url))
          ;; Remove the leading "/" for local MS Windows-style paths.
          (normalized (if (and (not remote-prefix)
                               (eq system-type 'windows-nt)
                               (cl-plusp (length retval)))
                          (substring retval 1)
                        retval)))
+    (when (not (string-equal "file" (downcase (url-type url))))
+      (eglot--warn "URI with unexpected scheme: %s" uri))
     (concat remote-prefix normalized)))
 
 (defun eglot--snippet-expansion-fn ()


### PR DESCRIPTION
Eglot supports just one URI-scheme: "file".  This does not seem to be
a problem currently, but servers may send something else like "jdt" in
[1].  This patch takes a preventive step, so users would more easily
recognize when Eglot's assumption about the scheme fails helping them
to send valuable bug reports.

[1]: https://github.com/joaotavora/eglot/discussions/842

* eglot.el (eglot--uri-to-path): Warn if the URI-scheme is not "file".