### PR TITLE
Don't strip invisible text when formatting hover string

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1436,7 +1436,7 @@ Doubles as an indicator of snippet support."
 	    (message-log-max nil))
         (ignore-errors (delay-mode-hooks (funcall mode))))
       (font-lock-ensure)
-      (string-trim (filter-buffer-substring (point-min) (point-max))))))
+      (string-trim (buffer-string)))))
 
 (define-obsolete-variable-alias 'eglot-ignored-server-capabilites
   'eglot-ignored-server-capabilities "1.8")


### PR DESCRIPTION
This was introduced in #482 due to a bad interaction with a specific
server.  But this solution makes hyperlinks in Eldoc buffers
unclickable, because the markdown-mode function that visits a link
relies on the invisible text.

Fixes #865.

* eglot.el (eglot--format-markup): Don't use
'filter-buffer-substring'; instead, keep invisible text.