### PR TITLE
Per #853: Change capability 'documentChanges' to t

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -649,7 +649,7 @@ treated as in `eglot-dbind'."
             :workspace (list
                         :applyEdit t
                         :executeCommand `(:dynamicRegistration :json-false)
-                        :workspaceEdit `(:documentChanges :json-false)
+                        :workspaceEdit `(:documentChanges t)
                         :didChangeWatchedFiles `(:dynamicRegistration t)
                         :symbol `(:dynamicRegistration :json-false)
                         :configuration t)


### PR DESCRIPTION
Eglot does support woskspaceEdit/documentChanges, but failed to
advertise this fact.

* eglot.el (eglot-client-capabilities): Set documentChanges to t.