### PR TITLE
Adapt README to simplified JDT starting procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,6 @@ get [cquery][cquery] working:
           :progressReportFrequencyMs -1)))
 ```
 
-See `eglot.el`'s section on Java's JDT server for an even more
-sophisticated example.
-
 Similarly, some servers require the language identifier strings they
 are sent by `eglot` to match the exact strings used by VSCode. `eglot`
 usually guesses these identifiers from the major mode name


### PR DESCRIPTION
* README.md (Handling quirky servers): Remove outdated sentence about
complex JDT initialization.