### PR TITLE
Correct the default-directory used for remote files

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1401,9 +1401,10 @@ If optional MARKER, return a marker instead"
   "Convert URI to file path, helped by `eglot--current-server'."
   (when (keywordp uri) (setq uri (substring (symbol-name uri) 1)))
   (let* ((server (eglot-current-server))
-         (remote-prefix (and server
-                             (file-remote-p
-                              (project-root (eglot--project server)))))
+         (remote-prefix (when (and server
+                                   (file-remote-p
+                                    (project-root (eglot--project server))))
+                          (project-root (eglot--project server))))
          (retval (url-filename (url-generic-parse-url (url-unhex-string uri))))
          ;; Remove the leading "/" for local MS Windows-style paths.
          (normalized (if (and (not remote-prefix)


### PR DESCRIPTION
As discussed in https://github.com/joaotavora/eglot/discussions/876, I think there's a bug in `eglot--uri-to-path`:

The return value of eglot--uri-to-path in remote projects used to be the return value of file-remote-p concatenated with the (empty) file URI, which strips the project prefix, and loses the location information for dir-locals files.

Instead, now we use the entire project root - which at least returns gets us as far as the project root dir (the file URI is still empty, so deeper-nested dir-locals won't be used).

This PR adjusts that behavior, but I'm not sure why remote connections to pyright yield URIs that are `""`. Maybe there's a deeper bug that I'm not seeing, in which case this PR is invalid.