### PR TITLE
Change dart language server to analysis_server provided with the Dart SDK.

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -174,7 +174,7 @@ language-server/bin/php-language-server.php"))
                                 ((R-mode ess-r-mode) . ("R" "--slave" "-e"
                                                         "languageserver::run()"))
                                 (java-mode . ("jdtls"))
-                                (dart-mode . ("dart_language_server"))
+                                (dart-mode . ("dart" "language-server"))
                                 (elixir-mode . ("language_server.sh"))
                                 (ada-mode . ("ada_language_server"))
                                 (scala-mode . ("metals-emacs"))


### PR DESCRIPTION
The language server currently set for dart is dart_language_server, but it is now deprecated and suggests to use language server included in Dart SDK (https://github.com/natebosch/dart_lsp).

According to the new language server page(https://github.com/dart-lang/sdk/tree/master/pkg/analysis_server/tool/lsp_spec), it accepts two command line options: --client-id and --client-version.

But I don't set these options in this pull request. Because it works and I'm not sure what should be set in this case.
