### PR TITLE
Add quirk support for initialize parameters

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -642,8 +642,8 @@ treated as in `eglot-dbind'."
    (eglot--warn "Server tried to unregister unsupported capability `%s'"
                 method)))
 
-(cl-defgeneric eglot-client-initialize-params (server)
-  "Additional parameters for EGLOT LSP client initialization for SERVER."
+(cl-defgeneric eglot-workspace-folders (server)
+  "Workspace folders configured in EGLOT LSP client for SERVER."
   (:method (_s) nil))
 
 (cl-defgeneric eglot-client-capabilities (server)
@@ -1155,22 +1155,21 @@ This docstring appeases checkdoc, that's all."
                      (jsonrpc-async-request
                       server
                       :initialize
-                      (append
-                       (list :processId
-                             (unless (or eglot-withhold-process-id
-                                         (file-remote-p default-directory)
-                                         (eq (jsonrpc-process-type server)
-                                             'network))
-                               (emacs-pid))
-                             ;; Maybe turn trampy `/ssh:foo@bar:/path/to/baz.py'
-                             ;; into `/path/to/baz.py', so LSP groks it.
-                             :rootPath (file-local-name
-                                        (expand-file-name default-directory))
-                             :rootUri (eglot--path-to-uri default-directory)
-                             :initializationOptions (eglot-initialization-options
-                                                     server)
-                             :capabilities (eglot-client-capabilities server))
-                       (eglot-client-initialize-params server))
+                      (list :processId
+                            (unless (or eglot-withhold-process-id
+                                        (file-remote-p default-directory)
+                                        (eq (jsonrpc-process-type server)
+                                            'network))
+                              (emacs-pid))
+                            ;; Maybe turn trampy `/ssh:foo@bar:/path/to/baz.py'
+                            ;; into `/path/to/baz.py', so LSP groks it.
+                            :rootPath (file-local-name
+                                       (expand-file-name default-directory))
+                            :rootUri (eglot--path-to-uri default-directory)
+                            :initializationOptions (eglot-initialization-options
+                                                    server)
+                            :capabilities (eglot-client-capabilities server)
+                            :workspaceFolders (eglot-workspace-folders server))
                       :success-fn
                       (eglot--lambda ((InitializeResult) capabilities serverInfo)
                         (unless cancelled

--- a/eglot.el
+++ b/eglot.el
@@ -644,7 +644,10 @@ treated as in `eglot-dbind'."
 
 (cl-defgeneric eglot-workspace-folders (server)
   "Workspace folders configured in EGLOT LSP client for SERVER."
-  (:method (_s) nil))
+  (:method (_s)
+           ;; rootUri is deprecated in favor of workspaceFolders
+           ;; initialize workspaceFolders[0] with rootUri
+           `[(:name "rootUri" :uri ,(eglot--path-to-uri default-directory))]))
 
 (cl-defgeneric eglot-client-capabilities (server)
   "What the EGLOT LSP client supports for SERVER."


### PR DESCRIPTION
Certain language servers require non-standard parameters to be passed as part of their initialization. Currently eglot does not support providing additional base parameters outside of the
initializationOptions and capabilities.

Adding a generic function that defaults to an empty list allows users to provide custom parameters to deal with such quirks.

An example is the CodeQL language server, which expects the workspaceFolders parameter to set.

With these changes in place you can support such this language server quirk with something like:
```elisp
(defclass eglot-codeql (eglot-lsp-server) ()
  :documentation "A custom class for CodeQL's langserver.")

(cl-defmethod eglot-client-initialize-params ((server eglot-codeql))
  "Add :workspaceFolders parameter to EGLOT initialization for SERVER of type EGLOT-CODEQL."
  (let ((root (car (project-roots (eglot--project server)))))
    `(:workspaceFolders [(:name "workspace" :uri ,(eglot--path-to-uri root))])))

(add-to-list 'eglot-server-programs
             `((ql-mode) .
               (eglot-codeql . ("<path to codeql executable>"
                                "execute" "language-server"
                                "--search-path" "./:<path to codeql repo>"
                                "--check-errors" "ON_CHANGE"
                                "-q" "--log-to-stderr"))))
```