### PR TITLE
Add C# server Omnisharp to server list

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ find-library` can help you tell if that happened.
 * Ada's [ada_language_server][ada_language_server]
 * Bash's [bash-language-server][bash-language-server]
 * C/C++'s [clangd][clangd] or [ccls][ccls]
+* C#'s [omnisharp][omnisharp]
 * Clojure's [clojure-lsp][clojure-lsp]
 * CMake's [cmake-language-server][cmake-language-server]
 * CSS's [css-languageserver][css-languageserver]
@@ -501,6 +502,7 @@ for the request form, and we'll send it to you.
 [ada_language_server]: https://github.com/AdaCore/ada_language_server
 [bash-language-server]: https://github.com/mads-hartmann/bash-language-server
 [clangd]: https://clang.llvm.org/extra/clangd.html
+[omnisharp]: https://github.com/OmniSharp/omnisharp-roslyn
 [clojure-lsp]: https://clojure-lsp.io
 [cmake-language-server]: https://github.com/regen100/cmake-language-server
 [css-languageserver]: https://github.com/hrsh7th/vscode-langservers-extracted

--- a/eglot.el
+++ b/eglot.el
@@ -192,7 +192,8 @@ language-server/bin/php-language-server.php"))
                                 (html-mode . ,(eglot-alternatives '(("vscode-html-language-server" "--stdio") ("html-languageserver" "--stdio"))))
                                 (json-mode . ,(eglot-alternatives '(("vscode-json-language-server" "--stdio") ("json-languageserver" "--stdio"))))
                                 (dockerfile-mode . ("docker-langserver" "--stdio"))
-                                (clojure-mode . ("clojure-lsp")))
+                                (clojure-mode . ("clojure-lsp"))
+                                (csharp-mode . ("omnisharp" "-lsp")))
   "How the command `eglot' guesses the server to start.
 An association list of (MAJOR-MODE . CONTACT) pairs.  MAJOR-MODE
 identifies the buffers that are to be managed by a specific


### PR DESCRIPTION
There are several issues that report that the Omnisharp server works well together with Eglot, e.g. https://github.com/joaotavora/eglot/issues/241. I have also tested it and it seems to work well. So it would be good if it could be added to the server list.