### PR TITLE
Implement on-type-formatting support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # (upcoming)
 
+##### Support on-type-formatting ([#899][github#899])
+
 ##### Provide basic workspace-folders support ([#893][github#893])
 Eglot now advertises `project-root` and `project-external-roots` as
 workspace-folders.  (Configuring `tags-table-list` sets the external
@@ -355,3 +357,4 @@ and now said bunch of references-->
 [github#810]: https://github.com/joaotavora/eglot/issues/810
 [github#813]: https://github.com/joaotavora/eglot/issues/813
 [github#893]: https://github.com/joaotavora/eglot/issues/893
+[github#899]: https://github.com/joaotavora/eglot/issues/899

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,7 +26,7 @@ rendering suggestions in the protocol, we fade out unnecessary code
 and strike-through deprecated code.
 
 ##### The Rust language server is now rust-analyzer by default ([#803][github#803])
-Eglot will now prefer starting "rust-analazyer" to "rls" when it is
+Eglot will now prefer starting "rust-analyzer" to "rls" when it is
 available.  The special support code for RLS has been removed.
 
 ##### New servers have been added to `eglot-server-programs`


### PR DESCRIPTION
* eglot.el (eglot--on-type-formatting-chars): New local var, set
and unset ...
(eglot--managed-mode): ... here based on server's
documentOnTypeFormatting capability, ...
(eglot--post-self-insert-hook): and used here to call eglot-format
for on-type-formatting characters.
(eglot-format): Add new optional argument character to request
:textDocument/onTypeFormatting.

* eglot-tests.el (eglot--simulate-key-event): New helper defun.
(rust-on-type-formatting): New test.