### PR TITLE
Map more Emacs variables to fields in FormattingOptions

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2380,7 +2380,9 @@ is not active."
       (cl-list*
        :textDocument (eglot--TextDocumentIdentifier)
        :options (list :tabSize tab-width
-                      :insertSpaces (if indent-tabs-mode :json-false t))
+                      :insertSpaces (if indent-tabs-mode :json-false t)
+                      :insertFinalNewline (if require-final-newline t :json-false)
+                      :trimFinalNewlines (if delete-trailing-lines t :json-false))
        args)
       :deferred method))))
 


### PR DESCRIPTION
these Emacs variables match to the LSP counterparts.  But this kind of mapping is always debatable.   Nevertheless, I think these make sense.

---

* eglot.el (eglot-format): Map require-final-newline to
insertFinalNewline and delete-trailing-lines to trimFinalNewlines.