### PR TITLE
Easier initializationOptions in eglot-server-programs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # (upcoming)
 
+##### Easier to use LSP initialize.initializationOptions
+For controlling some servers' startup, in `eglot-server-programs` a
+plist can be appended to the usual list of strings passed as command
+line arguments.  The value of its `:initializationOptions` key is
+another plist used to construct the corresponding LSP JSON object.
+This may be easier than creating `defclass` for a specific server and
+specializing `eglot-initialization-options` to that class.
+
 ##### Provide basic workspace-folders support ([#893][github#893])
 Eglot now advertises `project-root` and `project-external-roots` as
 workspace-folders.  (Configuring `tags-table-list` sets the external

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,11 @@
 # (upcoming)
 
 ##### Easier to use LSP initialize.initializationOptions
-For controlling some servers' startup, in `eglot-server-programs` a
-plist can be appended to the usual list of strings passed as command
-line arguments.  The value of its `:initializationOptions` key is
-another plist used to construct the corresponding LSP JSON object.
-This may be easier than creating `defclass` for a specific server and
+For controlling server startup, a plist can be appended to the usual
+list of strings passed as command line arguments in
+`eglot-server-programs`.  The value of its `:initializationOptions`
+key is used to construct the corresponding LSP JSON object.  This may
+be easier than creating `defclass` for a specific server and
 specializing `eglot-initialization-options` to that class.
 
 ##### Provide basic workspace-folders support ([#893][github#893])

--- a/eglot.el
+++ b/eglot.el
@@ -221,7 +221,9 @@ CONTACT can be:
 * A list (PROGRAM [ARGS...] :initializationOptions OPTIONS),
   whereupon PROGRAM is called with ARGS as in the first option,
   and the LSP \"initializationOptions\" JSON object is
-  constructed from the plist OPTIONS.
+  constructed from OPTIONS.  If OPTIONS is plist, contruction is
+  direct, if a function it is called with the server instance and
+  should return a plist.
 
 * A list (HOST PORT [TCP-ARGS...]) where HOST is a string and
   PORT is a positive integer for connecting to a server via TCP.
@@ -632,9 +634,11 @@ treated as in `eglot-dbind'."
 
 (cl-defgeneric eglot-initialization-options (server)
   "JSON object to send under `initializationOptions'."
-  (:method (s) (or (plist-get (eglot--saved-initargs s)
-                              :initializationOptions)
-                   eglot--{})))
+  (:method (s)
+   (let ((probe (plist-get (eglot--saved-initargs s) :initializationOptions)))
+     (cond ((functionp probe) (funcall probe s))
+           (probe)
+           (t eglot--{})))))
 
 (cl-defgeneric eglot-register-capability (server method id &rest params)
   "Ask SERVER to register capability METHOD marked with ID."

--- a/eglot.el
+++ b/eglot.el
@@ -218,17 +218,22 @@ CONTACT can be:
   PROGRAM is called with ARGS and is expected to serve LSP requests
   over the standard input/output channels.
 
+* A list (PROGRAM [ARGS...] :initializationOptions OPTIONS),
+  whereupon PROGRAM is called with ARGS as in the first option,
+  and the LSP \"initializationOptions\" JSON object is
+  constructed from the plist OPTIONS.
+
 * A list (HOST PORT [TCP-ARGS...]) where HOST is a string and
   PORT is a positive integer for connecting to a server via TCP.
   Remaining ARGS are passed to `open-network-stream' for
   upgrading the connection with encryption or other capabilities.
 
 * A list (PROGRAM [ARGS...] :autoport [MOREARGS...]), whereupon a
-  combination of the two previous options is used.  First, an
-  attempt is made to find an available server port, then PROGRAM
-  is launched with ARGS; the `:autoport' keyword substituted for
-  that number; and MOREARGS.  Eglot then attempts to establish a
-  TCP connection to that port number on the localhost.
+  combination of previous options is used.  First, an attempt is
+  made to find an available server port, then PROGRAM is launched
+  with ARGS; the `:autoport' keyword substituted for that number;
+  and MOREARGS.  Eglot then attempts to establish a TCP
+  connection to that port number on the localhost.
 
 * A cons (CLASS-NAME . INITARGS) where CLASS-NAME is a symbol
   designating a subclass of `eglot-lsp-server', for representing
@@ -627,7 +632,9 @@ treated as in `eglot-dbind'."
 
 (cl-defgeneric eglot-initialization-options (server)
   "JSON object to send under `initializationOptions'."
-  (:method (_s) eglot--{})) ; blank default
+  (:method (s) (or (plist-get (eglot--saved-initargs s)
+                              :initializationOptions)
+                   eglot--{})))
 
 (cl-defgeneric eglot-register-capability (server method id &rest params)
   "Ask SERVER to register capability METHOD marked with ID."
@@ -1116,18 +1123,22 @@ This docstring appeases checkdoc, that's all."
                                  (setq autostart-inferior-process inferior)
                                  connection))))
                 ((stringp (car contact))
-                 `(:process
-                   ,(lambda ()
-                      (let ((default-directory default-directory))
-                        (make-process
-                         :name readable-name
-                         :command (setq server-info (eglot--cmd contact))
-                         :connection-type 'pipe
-                         :coding 'utf-8-emacs-unix
-                         :noquery t
-                         :stderr (get-buffer-create
-                                  (format "*%s stderr*" readable-name))
-                         :file-handler t)))))))
+                 (let* ((probe (cl-position-if #'keywordp contact))
+                        (more-initargs (and probe (cl-subseq contact probe)))
+                        (contact (cl-subseq contact 0 probe)))
+                   `(:process
+                     ,(lambda ()
+                        (let ((default-directory default-directory))
+                          (make-process
+                           :name readable-name
+                           :command (setq server-info (eglot--cmd contact))
+                           :connection-type 'pipe
+                           :coding 'utf-8-emacs-unix
+                           :noquery t
+                           :stderr (get-buffer-create
+                                    (format "*%s stderr*" readable-name))
+                           :file-handler t)))
+                     ,@more-initargs)))))
          (spread (lambda (fn) (lambda (server method params)
                                 (let ((eglot--cached-server server))
                                  (apply fn server method (append params nil))))))


### PR DESCRIPTION
* NEWS.md: Update.

* eglot.el (eglot-server-programs): Document new syntax.
(eglot-initialization-options): Can use initializationOptions from
server's saved initargs.
(eglot--connect): Allow a plist to be appended to a server
contact.