### PR TITLE
* Makefile (interactive-noelpa): New target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,9 @@ interactive: compile
 		-l eglot						\
 		-l eglot-tests						\
 
+interactive-noelpa: ELPADEPS=-f package-initialize
+interactive-noelpa: interactive
+
 check: eglot-check-noelpa
 
 # Cleanup


### PR DESCRIPTION
Sometimes I find this useful because it is safer/cleaner than using my .emacs and faster to set up than starting from `emacs -Q` or from `make interactive`