### PR TITLE
Check that ot-provider :firstTriggerCharacter isn’t empty

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1993,8 +1993,9 @@ THINGS are either registrations or unregisterations (sic)."
   (setq eglot--last-inserted-char last-input-event)
   (let ((ot-provider (eglot--server-capable :documentOnTypeFormattingProvider)))
     (when (and ot-provider
-               (or (eq last-input-event
-                       (elt (plist-get ot-provider :firstTriggerCharacter) 0))
+               (or (and (length> (plist-get ot-provider :firstTriggerCharacter) 0)
+                        (eq last-input-event
+                            (elt (plist-get ot-provider :firstTriggerCharacter) 0)))
                    (cl-find last-input-event
                             (plist-get ot-provider :moreTriggerCharacter)
                             :key #'seq-first)))


### PR DESCRIPTION
The :firstTriggerCharacter provided by gopls is empty, so we need to
check that it isn’t empty before calling elt on it.  I’m not sure
whether gopls is breaking the specification here, but it’s the world we
live in.