### PR TITLE
Fix the the GitHub Actions badge link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build status](https://github.com/joaotavora/eglot/actions/workflows/test.yml/badge.svg?master)
+[![Build status](https://github.com/joaotavora/eglot/actions/workflows/test.yml/badge.svg)](https://github.com/joaotavora/eglot/actions/workflows/test.yml)
 [![GNU ELPA](https://elpa.gnu.org/packages/eglot.svg)](https://elpa.gnu.org/packages/eglot.html)
 [![MELPA](https://melpa.org/packages/eglot-badge.svg)](https://melpa.org/#/eglot)
 


### PR DESCRIPTION
Currently it just links to an image of itself.