### PR TITLE
Use format string instead of concat

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1959,7 +1959,7 @@ COMMAND is a symbol naming the command."
                     ((= sev 2)  'eglot-warning)
                     (t          'eglot-note)))
             (mess (source code message)
-              (concat source (and code (concat " [" code "]")) ": " message)))
+              (concat source (and code (format " [%s]" code)) ": " message)))
     (if-let ((buffer (find-buffer-visiting (eglot--uri-to-path uri))))
         (with-current-buffer buffer
           (cl-loop


### PR DESCRIPTION
See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic

The diagnostics code can be `integer | string`, and the current implementation crashes on `tsserver` because of the integer it returns. This is a small fix to deal with that.