### PR TITLE
Add out-of-box support for Perl LSP server

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,8 +45,8 @@ available.  The special support code for RLS has been removed.
 ##### New servers have been added to `eglot-server-programs`
 - clojure-lsp ([#813][github#813])
 - racket-langserver ([#694][github#694])
-- futhark lsp ([#922](github#922))
-- purescript-language-server ([#905](github#905))
+- futhark lsp ([#922][github#922])
+- purescript-language-server ([#905][github#905])
 
 # 1.8 (12/1/2022)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,7 @@ available.  The special support code for RLS has been removed.
 - racket-langserver ([#694][github#694])
 - futhark lsp ([#922][github#922])
 - purescript-language-server ([#905][github#905])
+- Perl::LanguageServer ([#952][github#952])
 
 # 1.8 (12/1/2022)
 
@@ -378,3 +379,4 @@ and now said bunch of references-->
 [github#901]: https://github.com/joaotavora/eglot/issues/901
 [github#905]: https://github.com/joaotavora/eglot/issues/905
 [github#922]: https://github.com/joaotavora/eglot/issues/922
+[github#952]: https://github.com/joaotavora/eglot/issues/952

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ find-library` can help you tell if that happened.
 * Mint's [mint-ls][mint-ls]
 * Nix's [rnix-lsp][rnix-lsp]
 * Ocaml's [ocaml-lsp][ocaml-lsp]
+* Perl's [Perl::LanguageServer][perl-language-server]
 * PHP's [php-language-server][php-language-server]
 * PureScript's [purescript-language-server][purescript-language-server]
 * Python's [pylsp][pylsp], [pyls][pyls] or [pyright][pyright]
@@ -522,6 +523,7 @@ for the request form, and we'll send it to you.
 [mint-ls]: https://www.mint-lang.com/
 [rnix-lsp]: https://github.com/nix-community/rnix-lsp
 [ocaml-lsp]: https://github.com/ocaml/ocaml-lsp/
+[perl-language-server]: https://github.com/richterger/Perl-LanguageServer
 [php-language-server]: https://github.com/felixfbecker/php-language-server
 [purescript-language-server]: https://github.com/nwolverson/purescript-language-server
 [pyls]: https://github.com/palantir/python-language-server

--- a/eglot.el
+++ b/eglot.el
@@ -196,7 +196,8 @@ language-server/bin/php-language-server.php"))
                                 (dockerfile-mode . ("docker-langserver" "--stdio"))
                                 (clojure-mode . ("clojure-lsp"))
                                 (csharp-mode . ("omnisharp" "-lsp"))
-                                (purescript-mode . ("purescript-language-server" "--stdio")))
+                                (purescript-mode . ("purescript-language-server" "--stdio"))
+                                (perl-mode . ("perl" "-MPerl::LanguageServer" "-e" "Perl::LanguageServer::run")))
   "How the command `eglot' guesses the server to start.
 An association list of (MAJOR-MODE . CONTACT) pairs.  MAJOR-MODE
 identifies the buffers that are to be managed by a specific


### PR DESCRIPTION
This adds support for the Perl::LanguageServer module which implements an LSP server for the Perl language.
I'll rebase the commit as soon as I have the PullRequest number to make the NEWS.md entry.

I have done the FSF copyright paperwork some years ago, I have contributed to official Emacs:
https://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/org/ob-vala.el?h=emacs-27#n5 (`ob-vala.el` has since been moved to org-contrib, so it's not part of Org 9.5 or Emacs 28 any more as I have just found out).
Is this enough proof to skip the "copyright exemption" tag?

The available server features are:
```
[server-reply] (id:1) Thu May 12 22:05:45 2022:
(:id 1 :jsonrpc "2.0" :result
     (:capabilities
      (:documentRangeFormattingProvider t :workspaceSymbolProvider t :workspace
					(:workspaceFolders
					 (:supported t :changeNotifications t))
					:signatureHelpProvider
					(:triggerCharacters
					 ["("])
					:definitionProvider t :referencesProvider t :documentSymbolProvider t :textDocumentSync 1)))

```