### PR TITLE
Add support for jedi-language-server

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,7 @@ available.  The special support code for RLS has been removed.
 - racket-langserver ([#694][github#694])
 - futhark lsp ([#922](github#922))
 - purescript-language-server ([#905](github#905))
+- jedi-language-server ([#994](github#994))
 
 # 1.8 (12/1/2022)
 
@@ -378,3 +379,4 @@ and now said bunch of references-->
 [github#901]: https://github.com/joaotavora/eglot/issues/901
 [github#905]: https://github.com/joaotavora/eglot/issues/905
 [github#922]: https://github.com/joaotavora/eglot/issues/922
+[github#961]: https://github.com/joaotavora/eglot/pull/961

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ find-library` can help you tell if that happened.
 * Ocaml's [ocaml-lsp][ocaml-lsp]
 * PHP's [php-language-server][php-language-server]
 * PureScript's [purescript-language-server][purescript-language-server]
-* Python's [pylsp][pylsp], [pyls][pyls] or [pyright][pyright]
+* Python's [pylsp][pylsp], [pyls][pyls] [pyright][pyright], or [jedi-language-server][jedi-language-server]
 * R's [languageserver][r-languageserver]
 * Racket's [racket-langserver][racket-langserver]
 * Ruby's [solargraph][solargraph]
@@ -533,6 +533,7 @@ for the request form, and we'll send it to you.
 [godot]: https://godotengine.org
 [html-languageserver]: https://github.com/hrsh7th/vscode-langservers-extracted
 [haskell-language-server]: https://github.com/haskell/haskell-language-server
+[jedi-language-server]: https://github.com/pappasam/jedi-language-server
 [vscode-json-languageserver]: https://github.com/hrsh7th/vscode-langservers-extracted
 [eclipse-jdt]: https://github.com/eclipse/eclipse.jdt.ls
 [typescript-language-server]: https://github.com/theia-ide/typescript-language-server

--- a/eglot.el
+++ b/eglot.el
@@ -151,7 +151,7 @@ chosen (interactively or automatically)."
                                 (vimrc-mode . ("vim-language-server" "--stdio"))
                                 (python-mode
                                  . ,(eglot-alternatives
-                                     '("pylsp" "pyls" ("pyright-langserver" "--stdio"))))
+                                     '("pylsp" "pyls" ("pyright-langserver" "--stdio") "jedi-language-server")))
                                 ((js-mode typescript-mode)
                                  . ("typescript-language-server" "--stdio"))
                                 (sh-mode . ("bash-language-server" "start"))


### PR DESCRIPTION
Hi,

This adds support for [jedi-language-server](https://github.com/pappasam/jedi-language-server) so when I run `eglot` in the with `M-x` it will be detected and listed as one of the language server options. 

I found `jedi-language-server` to be quite performant and a nice experience with `eglot`.

`eglot` configuration is mentioned in the `jedi-language-server` `README`:

https://github.com/pappasam/jedi-language-server#emacs