### PR TITLE
Add Markdown LSP via Marksman

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,7 @@ available.  The special support code for RLS has been removed.
 - futhark lsp ([#922][github#922])
 - purescript-language-server ([#905][github#905])
 - Perl::LanguageServer ([#952][github#952])
+- marksman ([#1013][github#1013])
 
 # 1.8 (12/1/2022)
 
@@ -389,3 +390,4 @@ and now said bunch of references-->
 [github#922]: https://github.com/joaotavora/eglot/issues/922
 [github#952]: https://github.com/joaotavora/eglot/issues/952
 [github#967]: https://github.com/joaotavora/eglot/issues/967
+[github#1013]: https://github.com/joaotavora/eglot/pull/1013

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ find-library` can help you tell if that happened.
 * Javascript's [TS & JS Language Server][typescript-language-server]
 * Kotlin's [kotlin-language-server][kotlin-language-server]
 * Lua's [lua-lsp][lua-lsp]
+* Markdown's [marksman][marksman]
 * Mint's [mint-ls][mint-ls]
 * Nix's [rnix-lsp][rnix-lsp]
 * Ocaml's [ocaml-lsp][ocaml-lsp]
@@ -582,6 +583,7 @@ for the request form, and we'll send it to you.
 [typescript-language-server]: https://github.com/theia-ide/typescript-language-server
 [kotlin-language-server]: https://github.com/fwcd/KotlinLanguageServer
 [lua-lsp]: https://github.com/Alloyed/lua-lsp
+[marksman]: https://github.com/artempyanykh/marksman
 [mint-ls]: https://www.mint-lang.com/
 [rnix-lsp]: https://github.com/nix-community/rnix-lsp
 [ocaml-lsp]: https://github.com/ocaml/ocaml-lsp/

--- a/eglot.el
+++ b/eglot.el
@@ -197,7 +197,8 @@ language-server/bin/php-language-server.php"))
                                 (clojure-mode . ("clojure-lsp"))
                                 (csharp-mode . ("omnisharp" "-lsp"))
                                 (purescript-mode . ("purescript-language-server" "--stdio"))
-                                (perl-mode . ("perl" "-MPerl::LanguageServer" "-e" "Perl::LanguageServer::run")))
+                                (perl-mode . ("perl" "-MPerl::LanguageServer" "-e" "Perl::LanguageServer::run"))
+                                (markdown-mode . ("marksman" "server")))
   "How the command `eglot' guesses the server to start.
 An association list of (MAJOR-MODE . CONTACT) pairs.  MAJOR-MODE
 identifies the buffers that are to be managed by a specific


### PR DESCRIPTION
Marksman is an LSP server for Markdown: https://github.com/artempyanykh/marksman

It supports a bunch of LSP features such as symbols, references, rename, diagnostics, etc. and already has integrations with a number of LSP clients.

_Context_: I'm the author of Marksman and recently started using it with Eglot. I figured it would be nice to have an out-of-the-box support.