### PR TITLE
Fix #859: Force Eglot over Tramp to use a seperate channel

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1109,6 +1109,9 @@ Each function is passed the server as an argument")
 (defvar-local eglot--cached-server nil
   "A cached reference to the current EGLOT server.")
 
+(defvar tramp-ssh-controlmaster-options) ;; forward-declare
+(defvar tramp-use-ssh-controlmaster-options) ;; forward-declare
+
 (defun eglot--connect (managed-major-mode project class contact language-id)
   "Connect to MANAGED-MAJOR-MODE, LANGUAGE-ID, PROJECT, CLASS and CONTACT.
 This docstring appeases checkdoc, that's all."
@@ -1143,7 +1146,9 @@ This docstring appeases checkdoc, that's all."
                         (contact (cl-subseq contact 0 probe)))
                    `(:process
                      ,(lambda ()
-                        (let ((default-directory default-directory))
+                        (let ((default-directory default-directory)
+                              (tramp-use-ssh-controlmaster-options t)
+                              (tramp-ssh-controlmaster-options "-o ControlMaster=no"))
                           (make-process
                            :name readable-name
                            :command (setq server-info (eglot--cmd contact))


### PR DESCRIPTION
This fixes https://github.com/joaotavora/eglot/issues/859. Emacs hanging and giving reentrant issues was caused by Eglot sending information over the same SSH connection that Emacs uses. When lots of data is being sent to or from the remote language server, the connection gets sluggish. The solution is to disable ControlMaster for Eglot, which causes it to make a new connection. 

The downside is that the user might be prompted for the remote password, since a new SSH connection is being spawned. 

An improvement could be to make a custom variable so the user can select if they want Eglot to run on a separate connection. For some language servers, it might not be worth having a separate connection?