### PR TITLE
Per #1008: Fix jdtls support

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -173,7 +173,7 @@ language-server/bin/php-language-server.php"))
                                 (go-mode . ("gopls"))
                                 ((R-mode ess-r-mode) . ("R" "--slave" "-e"
                                                         "languageserver::run()"))
-                                (java-mode . ("jdtls"))
+                                (java-mode . ("jdtls" "-data" ".jdtls-cache"))
                                 (dart-mode . ("dart" "language-server"
                                               "--client-id" "emacs.eglot-dart"))
                                 (elixir-mode . ("language_server.sh"))


### PR DESCRIPTION
This change could eventually be removed when https://github.com/eclipse/eclipse.jdt.ls/pull/2207 gets merged.