### PR TITLE
introduction of less intrusive eglot--user-error

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -609,9 +609,9 @@ treated as in `eglot-dbind'."
                          ,obj-once
                        ,@body)))
         (t
-         (eglot--error "%S didn't match any of %S"
-                       ,obj-once
-                       ',(mapcar #'car clauses)))))))
+         (eglot--user-error "%S didn't match any of %S"
+                            ,obj-once
+                            ',(mapcar #'car clauses)))))))
 
 
 ;;; API (WORK-IN-PROGRESS!)
@@ -1321,6 +1321,13 @@ CONNECT-ARGS are passed as additional arguments to
 
 ;;; Helpers (move these to API?)
 ;;;
+
+(defun eglot--user-error (format &rest args)
+  "User errorewith FORMAT with ARGS.
+Should be used when error can be too intrusive, i.e. the users
+has `debug-on-error' set to non-nil values."
+  (user-error "[eglot] %s" (apply #'format format args)))
+
 (defun eglot--error (format &rest args)
   "Error out with FORMAT with ARGS."
   (error "[eglot] %s" (apply #'format format args)))
@@ -3135,7 +3142,7 @@ at point.  With prefix argument, prompt for ACTION-KIND."
                        when (or (not action-kind)
                                 (equal action-kind (plist-get action :kind)))
                        collect (cons (plist-get action :title) action))
-              (apply #'eglot--error
+              (apply #'eglot--user-error
                      (if action-kind `("No \"%s\" code actions here" ,action-kind)
                        `("No code actions here")))))
          (preferred-action (cl-find-if


### PR DESCRIPTION
### This is to address the discussion made in https://github.com/joaotavora/eglot/discussions/1053.

### Comments
There are two places where `eglot--user-error' is prefered over `eglot--error', which could be of annoyance when `debug-on-error' is set to non-nil value:

- Didn't match any of the commands
- No code action

### A relevant unhandle `nil` case in `eglot-code-actions` (`eglot--dcase`) when invoked as mouse buffer menu
Additionally, the "didn't match any of the commands" comes from `eglot--dcase` which this specific one comes from `eglot-code-actions` is erroring when none of the code action is selected in the mouse buffer menu, which results in nil and is not part of the case. 

So in that specific senario, it may be best to handle the `nil` case, however, the solution to that problem would be outside the scope of this commit. But if a solution has been found, I think it would be better to use `eglot--error`...