### PR TITLE
fix x-pop-menu returning nil when lost focus

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -3146,8 +3146,13 @@ at point.  With prefix argument, prompt for ACTION-KIND."
          (action (if (and action-kind (null (cadr menu-items)))
                      (cdr (car menu-items))
                    (if (listp last-nonmenu-event)
-                       (x-popup-menu last-nonmenu-event `("Eglot code actions:"
-                                                          ("dummy" ,@menu-items)))
+                       (x-popup-menu
+                        ;; Using t explicitly to quit, if menu lost
+                        ;; focus (see x-popup-menu).  Since mouse-1
+                        ;; moves point, t should be safe to use.
+                        t               ; last-nonmenu-event
+                        `("Eglot code actions:"
+                          ("dummy" ,@menu-items)))
                      (cdr (assoc (completing-read
                                   (format "[eglot] Pick an action (default %s): "
                                           default-action)


### PR DESCRIPTION
This is to address the issue found and commented in the PR https://github.com/joaotavora/eglot/pull/1054#issuecomment-1254329493.

Using `t` explicitly allows `x-pop-menu` to quit instead of returning `nil` when mouse button event is passed.
Otherwise, the dcase later on will error out on the `nil` action.

I used the term lost fucs, which I mean that the focus is lost when the user gets rid of the menu without making a valid choice... (see `(describe-function x-pop-menu)`)

