### PR TITLE
Add `ltex-ls` to supported servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,20 +60,22 @@ find-library` can help you tell if that happened.
 * Javascript's [TS & JS Language Server][typescript-language-server]
 * Kotlin's [kotlin-language-server][kotlin-language-server]
 * Lua's [lua-lsp][lua-lsp]
-* Markdown's [marksman][marksman]
+* Markdown's [marksman][marksman] or [ltex-ls][ltex-ls]
 * Mint's [mint-ls][mint-ls]
 * Nix's [rnix-lsp][rnix-lsp]
 * Ocaml's [ocaml-lsp][ocaml-lsp]
+* Org's [ltex-ls][ltex-ls]
 * Perl's [Perl::LanguageServer][perl-language-server]
 * PHP's [php-language-server][php-language-server]
 * PureScript's [purescript-language-server][purescript-language-server]
 * Python's [pylsp][pylsp], [pyls][pyls] [pyright][pyright], or [jedi-language-server][jedi-language-server]
 * R's [languageserver][r-languageserver]
 * Racket's [racket-langserver][racket-langserver]
+* reStructuredText's [ltex-ls][ltex-ls]
 * Ruby's [solargraph][solargraph]
 * Rust's [rust-analyzer][rust-analyzer]
 * Scala's [metals][metals]
-* TeX/LaTeX's [Digestif][digestif]
+* TeX/LaTeX's [Digestif][digestif] or [ltex-ls][ltex-ls]
 * VimScript's [vim-language-server][vim-language-server]
 * YAML's [yaml-language-server][yaml-language-server]
 * Zig's [zls][zls]
@@ -243,6 +245,7 @@ for the request form, and we'll send it to you.
 [typescript-language-server]: https://github.com/theia-ide/typescript-language-server
 [kotlin-language-server]: https://github.com/fwcd/KotlinLanguageServer
 [lua-lsp]: https://github.com/Alloyed/lua-lsp
+[ltex-ls]: https://github.com/valentjn/ltex-ls
 [marksman]: https://github.com/artempyanykh/marksman
 [mint-ls]: https://www.mint-lang.com/
 [rnix-lsp]: https://github.com/nix-community/rnix-lsp

--- a/eglot.el
+++ b/eglot.el
@@ -184,7 +184,7 @@ language-server/bin/php-language-server.php"))
                                 (scala-mode . ("metals-emacs"))
                                 (racket-mode . ("racket" "-l" "racket-langserver"))
                                 ((tex-mode context-mode texinfo-mode bibtex-mode)
-                                 . ("digestif"))
+                                 . ,(eglot-alternatives '(("digestif") ("ltex-ls"))))
                                 (erlang-mode . ("erlang_ls" "--transport" "stdio"))
                                 (yaml-mode . ("yaml-language-server" "--stdio"))
                                 (nix-mode . ("rnix-lsp"))
@@ -202,7 +202,8 @@ language-server/bin/php-language-server.php"))
                                 (csharp-mode . ("omnisharp" "-lsp"))
                                 (purescript-mode . ("purescript-language-server" "--stdio"))
                                 (perl-mode . ("perl" "-MPerl::LanguageServer" "-e" "Perl::LanguageServer::run"))
-                                (markdown-mode . ("marksman" "server")))
+                                (markdown-mode . ,(eglot-alternatives '(("marksman" "server") ("ltex-ls"))))
+                                ((org-mode rst-mode) . ("ltex-ls")))
   "How the command `eglot' guesses the server to start.
 An association list of (MAJOR-MODE . CONTACT) pairs.  MAJOR-MODE
 identifies the buffers that are to be managed by a specific


### PR DESCRIPTION
First, thank you so much for this beautiful package, I moved to Eglot some time ago, and I'm really surprised by its power yet simplicity, congratulations on that!

This PR adds [ltex-ls](https://github.com/valentjn/ltex-ls) support, which is is a server that provides LanguageTool integration via LSP, which gives advanced natural languages checking (grammar and so on) for text documents. 

This PR:

- Add `ltex-ls` for relevant modes, as a second choice for existing ones (Latex related and Markdown).
- Mention it in the README, in the relevant modes.

LTeX supports Org mode, LaTeX, reStructuredText (... and others), and so, do not give much false positives as it understands the markup language's structure.

I'm using it regularly, and it works fine with Eglot, it can be customized using the `eglot-workspace-configuration`, for example, by adding this in the `dir-locals.el` file:

```elisp
((nil (eglot-workspace-configuration
       . ((ltex . ((language . "fr")
                   (disabledRules . ((fr . ["FRENCH_WHITESPACE"])))
                   (additionalRules . ((languageModel . "/usr/share/ngrams/")))))))))
```

More information about the server options and configuration options can be found at https://valentjn.github.io/ltex