### PR TITLE
Add support for Java server https://github.com/georgewfraser/java-lan…

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ servers][manual].
 * Haskell's [haskell-language-server][haskell-language-server]
 * JSON's [vscode-json-languageserver][vscode-json-languageserver]
 * Java's [Eclipse JDT Language Server][eclipse-jdt]
+* Java's [java-language-server][java-language-server]
 * Javascript's [TS & JS Language Server][typescript-language-server]
 * Kotlin's [kotlin-language-server][kotlin-language-server]
 * Lua's [lua-lsp][lua-lsp]
@@ -273,6 +274,7 @@ for the request form, and we'll send it to you.
 [jedi-language-server]: https://github.com/pappasam/jedi-language-server
 [vscode-json-languageserver]: https://github.com/hrsh7th/vscode-langservers-extracted
 [eclipse-jdt]: https://github.com/eclipse/eclipse.jdt.ls
+[java-language-server]: https://github.com/georgewfraser/java-language-server
 [typescript-language-server]: https://github.com/theia-ide/typescript-language-server
 [kotlin-language-server]: https://github.com/fwcd/KotlinLanguageServer
 [lua-lsp]: https://github.com/Alloyed/lua-lsp

--- a/eglot.el
+++ b/eglot.el
@@ -207,7 +207,8 @@ language-server/bin/php-language-server.php"))
                                 (go-mode . ("gopls"))
                                 ((R-mode ess-r-mode) . ("R" "--slave" "-e"
                                                         "languageserver::run()"))
-                                (java-mode . ("jdtls"))
+                                (java-mode
+                                 . ,(eglot-alternatives '("jdtls" "java-language-server")))
                                 (dart-mode . ("dart" "language-server"
                                               "--client-id" "emacs.eglot-dart"))
                                 (elixir-mode . ("language_server.sh"))
@@ -228,7 +229,7 @@ language-server/bin/php-language-server.php"))
                                 (html-mode . ,(eglot-alternatives '(("vscode-html-language-server" "--stdio") ("html-languageserver" "--stdio"))))
                                 (json-mode . ,(eglot-alternatives '(("vscode-json-language-server" "--stdio") ("json-languageserver" "--stdio"))))
                                 (dockerfile-mode . ("docker-langserver" "--stdio"))
-                                ((clojure-mode clojurescript-mode clojurec-mode) 
+                                ((clojure-mode clojurescript-mode clojurec-mode)
                                  . ("clojure-lsp"))
                                 (csharp-mode . ("omnisharp" "-lsp"))
                                 (purescript-mode . ("purescript-language-server" "--stdio"))


### PR DESCRIPTION
I have been using eglot with George Fraser's java-language-server for many months.
This commit adds that server as a an alternative to the Eclipse-based language server for Java.
