### PR TITLE
Ignore errors when shutting down all servers

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -872,7 +872,9 @@ SERVER."
 PRESERVE-BUFFERS as in `eglot-shutdown', which see."
   (interactive (list current-prefix-arg))
   (cl-loop for ss being the hash-values of eglot--servers-by-project
-           do (cl-loop for s in ss do (eglot-shutdown s nil preserve-buffers))))
+           do (cl-loop for s in ss do (with-demoted-errors
+                                          "[eglot] shutdown all: %s"
+                                        (eglot-shutdown s nil preserve-buffers)))))
 
 (defun eglot--on-shutdown (server)
   "Called by jsonrpc.el when SERVER is already dead."


### PR DESCRIPTION
eglot-shutdown-all has a bug that results in partially stopping servers - when a server shutdown timeouts (1.5s), an error is propagated and eglot-shutdown-all does not try to shutdown the rest of the servers.

* eglot.el (eglot-shutdown-all): Ignore errors when shutting down servers, converting errors to messages.