### PR TITLE
Add eglot-alternatives for PHP

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -190,8 +190,10 @@ chosen (interactively or automatically)."
                                  . ("typescript-language-server" "--stdio"))
                                 (sh-mode . ("bash-language-server" "start"))
                                 ((php-mode phps-mode)
-                                 . ("php" "vendor/felixfbecker/\
-language-server/bin/php-language-server.php"))
+                                 . ,(eglot-alternatives
+                                     '(("phpactor" "language-server")
+                                       ("intelephense" "--stdio")
+                                       ("php" "vendor/felixfbecker/language-server/bin/php-language-server.php"))))
                                 ((c++-mode c-mode) . ,(eglot-alternatives
                                                        '("clangd" "ccls")))
                                 (((caml-mode :language-id "ocaml")


### PR DESCRIPTION
resolve https://github.com/joaotavora/eglot/issues/537

Probably the most popular language server is [Intelephense](https://intelephense.com/), but it's not free software so [Phpactor](https://github.com/phpactor/phpactor) deserves preference.

#537 also mentions [Serenata](https://gitlab.com/Serenata/Serenata), but I'm not that user so I didn't add it here.
