### PR TITLE
Use the same server command for cperl mode as perl mode

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -233,6 +233,7 @@ language-server/bin/php-language-server.php"))
                                 (csharp-mode . ("omnisharp" "-lsp"))
                                 (purescript-mode . ("purescript-language-server" "--stdio"))
                                 (perl-mode . ("perl" "-MPerl::LanguageServer" "-e" "Perl::LanguageServer::run"))
+                                (cperl-mode . ("perl" "-MPerl::LanguageServer" "-e" "Perl::LanguageServer::run"))
                                 (markdown-mode . ("marksman" "server")))
   "How the command `eglot' guesses the server to start.
 An association list of (MAJOR-MODE . CONTACT) pairs.  MAJOR-MODE


### PR DESCRIPTION
cperl-mode is an improvement over vanilla perl-mode, eglot should just work with both.