### PR TITLE
adds clojure tree-sitter mode

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -242,7 +242,7 @@ chosen (interactively or automatically)."
                                                           ("css-languageserver" "--stdio"))))
                                 (html-mode . ,(eglot-alternatives '(("vscode-html-language-server" "--stdio") ("html-languageserver" "--stdio"))))
                                 ((dockerfile-mode dockerfile-ts-mode) . ("docker-langserver" "--stdio"))
-                                ((clojure-mode clojurescript-mode clojurec-mode)
+                                ((clojure-mode clojure-ts-mode clojurescript-mode clojurec-mode)
                                  . ("clojure-lsp"))
                                 ((csharp-mode csharp-ts-mode)
                                  . ,(eglot-alternatives


### PR DESCRIPTION
adds [clojure-ts-mode](https://github.com/clojure-emacs/clojure-ts-mode) to the list of modes associated with the clojure-lsp server.