### PR TITLE
gdscript default port is 6005

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -231,7 +231,7 @@ chosen (interactively or automatically)."
                                 (erlang-mode . ("erlang_ls" "--transport" "stdio"))
                                 ((yaml-ts-mode yaml-mode) . ("yaml-language-server" "--stdio"))
                                 (nix-mode . ,(eglot-alternatives '("nil" "rnix-lsp")))
-                                (gdscript-mode . ("localhost" 6008))
+                                (gdscript-mode . ("localhost" 6005))
                                 ((fortran-mode f90-mode) . ("fortls"))
                                 (futhark-mode . ("futhark" "lsp"))
                                 (lua-mode . ,(eglot-alternatives


### PR DESCRIPTION
The default port for godot lsp is defined in this file:[gdscript_language_server.h](https://github.com/godotengine/godot/blob/1d14c054a12dacdc193b589e4afb0ef319ee2aae/modules/gdscript/language_server/gdscript_language_server.h#L48)