### PR TITLE
Ensure default-directory ends in slash

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -2547,7 +2547,9 @@ use the root of SERVER's `eglot--project'."
   (let ((val (with-temp-buffer
                (setq default-directory
                      (if path
-                         (file-name-directory path)
+                         (if (file-directory-p path)
+                             (file-name-as-directory path)
+                           (file-name-directory path))
                        (project-root (eglot--project server))))
                ;; Set the major mode to be the first of the managed
                ;; modes.  This is the one the user started eglot in.


### PR DESCRIPTION
Pyright needs to be configured after initialization, as such, the server will make a `workspace/configuration` request after establishing a connection.  A typical request body contains a `scopeUri` that is a directory but does not end in a /.

The `scopeUri` is passed to `eglot--uri-to-path`, which does not canonicalize the path, i.e. makes sure if the path points to a directory, a / is always appended.  The output of such is then given to `eglot--workspace-configuration-plist` which assumes the path is always a file, so `file-name-directory` simply returns the parent of the project directory instead of the project directory, which in turns sets the `default-directory` incorrectly for looking up `eglot-workspace-configuration`.

This PR fixes this bug.
