### PR TITLE
Add support for typist-lsp when using typist-mode or typist-ts-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ variable, where you can [easily add your own servers][manual].
 * Rust's [rust-analyzer][rust-analyzer]
 * Scala's [metals][metals]
 * TeX/LaTeX's [Digestif][digestif] ot [texlab][texlab]
+* Typist's [typist-lsp][typist-lsp]
 * VimScript's [vim-language-server][vim-language-server]
 * YAML's [yaml-language-server][yaml-language-server]
 * Zig's [zls][zls]
@@ -303,6 +304,7 @@ for the request form, and we'll send it to you.
 [metals]: https://scalameta.org/metals/
 [digestif]: https://github.com/astoff/digestif
 [texlab]: https://github.com/latex-lsp/texlab
+[typist-lsp]: https://github.com/nvarner/typst-lsp
 [vim-language-server]: https://github.com/iamcco/vim-language-server
 [yaml-language-server]: https://github.com/redhat-developer/yaml-language-server
 [zls]: https://github.com/zigtools/zls

--- a/eglot.el
+++ b/eglot.el
@@ -254,6 +254,7 @@ chosen (interactively or automatically)."
                                  . ,(eglot-alternatives
                                      '(("marksman" "server")
                                        ("vscode-markdown-language-server" "--stdio"))))
+                                ((typst-mode typst-ts-mode) . ("typst-lsp"))
                                 (graphviz-dot-mode . ("dot-language-server" "--stdio")))
   "How the command `eglot' guesses the server to start.
 An association list of (MAJOR-MODE . CONTACT) pairs.  MAJOR-MODE


### PR DESCRIPTION
I chose to use https://github.com/Ziqi-Yang/typst-mode.el and https://git.sr.ht/~meow_king/typst-ts-mode as the base since some users may already be using typst-mode. I am open to removing typst-mode as it is publicly archived as of now.