### PR TITLE
Add nushell language server

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ variable, where you can [easily add your own servers][manual].
 * Markdown's [marksman][marksman]
 * Mint's [mint-ls][mint-ls]
 * Nix's [rnix-lsp][rnix-lsp]
+* Nushell's [nu-lsp][nu-lsp]
 * Ocaml's [ocaml-lsp][ocaml-lsp]
 * Perl's [Perl::LanguageServer][perl-language-server]
 * PHP's [php-language-server][php-language-server]
@@ -290,6 +291,7 @@ for the request form, and we'll send it to you.
 [lua-lsp]: https://github.com/Alloyed/lua-lsp
 [marksman]: https://github.com/artempyanykh/marksman
 [mint-ls]: https://www.mint-lang.com/
+[nu-lsp]: https://github.com/nushell/nushell/tree/main/crates/nu-lsp
 [rnix-lsp]: https://github.com/nix-community/rnix-lsp
 [ocaml-lsp]: https://github.com/ocaml/ocaml-lsp/
 [perl-language-server]: https://github.com/richterger/Perl-LanguageServer

--- a/eglot.el
+++ b/eglot.el
@@ -275,6 +275,7 @@ automatically)."
                                 ((yaml-ts-mode yaml-mode) . ("yaml-language-server" "--stdio"))
                                 (nix-mode . ,(eglot-alternatives '("nil" "rnix-lsp" "nixd")))
                                 (nickel-mode . ("nls"))
+                                ((nushell-mode nushell-ts-mode) . ("nu" "--lsp"))
                                 (gdscript-mode . ("localhost" 6008))
                                 ((fortran-mode f90-mode) . ("fortls"))
                                 (futhark-mode . ("futhark" "lsp"))


### PR DESCRIPTION
nvim-lspconfig and helix have LSP support for [Nushell](https://github.com/nushell/nushell), it would be nice if eglot could support it natively. 

https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig/server_configurations/nushell.lua
https://github.com/helix-editor/helix/blob/85fce2f5b6c9f35ab9d3361f3933288a28db83d4/languages.toml#L51

![lsp](https://github.com/joaotavora/eglot/assets/15247421/7a892cec-2f7c-464f-8d87-652c1021724d)
