### PR TITLE
Avoid message-spamming when jit-lock-context-unfontify-pos nil

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -3890,7 +3890,8 @@ If NOERROR, return predicate, else erroring function."
     ;; a lot of "non-contextual" calls come in all at once and do verify
     ;; the condition.  Notice it is a 0 second timer though, so we're
     ;; not introducing any more delay over jit-lock's timers.
-    (when (= jit-lock-context-unfontify-pos (point-max))
+    (when (and jit-lock-context-unfontify-pos
+               (= jit-lock-context-unfontify-pos (point-max)))
       (if timer (cancel-timer timer))
       (let ((buf (current-buffer)))
         (setq timer (run-at-time


### PR DESCRIPTION
In js-mode, I get an error with the message

      (jit-lock--run-functions 3698 3699) [UNPR HOST api.js]: Wrong type argument: number-or-marker-p, nil

for almost every edit. The nil-check in this patch fixes it. The variable is by default nil and docs say it can be nil if contextual fontification is disabled.