### PR TITLE
remove rnix-lsp, link nil and nixd

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ variable, where you can [easily add your own servers][manual].
 * Lua's [lua-lsp][lua-lsp]
 * Markdown's [marksman][marksman]
 * Mint's [mint-ls][mint-ls]
-* Nix's [rnix-lsp][rnix-lsp]
+* Nix's [nil][nil] or [nixd][nixd]
 * Ocaml's [ocaml-lsp][ocaml-lsp]
 * Perl's [Perl::LanguageServer][perl-language-server]
 * PHP's [php-language-server][php-language-server]
@@ -290,7 +290,8 @@ for the request form, and we'll send it to you.
 [lua-lsp]: https://github.com/Alloyed/lua-lsp
 [marksman]: https://github.com/artempyanykh/marksman
 [mint-ls]: https://www.mint-lang.com/
-[rnix-lsp]: https://github.com/nix-community/rnix-lsp
+[nil]: https://github.com/oxalica/nil
+[nixd]: https://github.com/nix-community/nixd
 [ocaml-lsp]: https://github.com/ocaml/ocaml-lsp/
 [perl-language-server]: https://github.com/richterger/Perl-LanguageServer
 [php-language-server]: https://github.com/felixfbecker/php-language-server

--- a/eglot.el
+++ b/eglot.el
@@ -273,7 +273,7 @@ automatically)."
                                  . ,(eglot-alternatives '("digestif" "texlab")))
                                 (erlang-mode . ("erlang_ls" "--transport" "stdio"))
                                 ((yaml-ts-mode yaml-mode) . ("yaml-language-server" "--stdio"))
-                                (nix-mode . ,(eglot-alternatives '("nil" "rnix-lsp" "nixd")))
+                                (nix-mode . ,(eglot-alternatives '("nil" "nixd")))
                                 (nickel-mode . ("nls"))
                                 (gdscript-mode . ("localhost" 6008))
                                 ((fortran-mode f90-mode) . ("fortls"))


### PR DESCRIPTION
rnix-lsp is an archived project as of January. It can no longer be securely installed due to dependence on nix 2.15, which has been marked insecure. Finally, I've merged the removal of rnix-lsp from nixpkgs. NixOS/nixpkgs#294488
