### PR TITLE
Add BasedPyright LSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ variable, where you can [easily add your own servers][manual].
 * Perl's [Perl::LanguageServer][perl-language-server]
 * PHP's [php-language-server][php-language-server]
 * PureScript's [purescript-language-server][purescript-language-server]
-* Python's [pylsp][pylsp], [pyls][pyls] [pyright][pyright], or [jedi-language-server][jedi-language-server]
+* Python's [pylsp][pylsp], [pyls][pyls], [basedpyright][basedpyright], [pyright][pyright], or [jedi-language-server][jedi-language-server]
 * R's [languageserver][r-languageserver]
 * Racket's [racket-langserver][racket-langserver]
 * Ruby's [solargraph][solargraph]
@@ -267,6 +267,7 @@ for the request form, and we'll send it to you.
 
 <!-- Language servers -->
 [ada_language_server]: https://github.com/AdaCore/ada_language_server
+[basedpyright]: https://detachhead.github.io/basedpyright
 [bash-language-server]: https://github.com/mads-hartmann/bash-language-server
 [clangd]: https://clang.llvm.org/extra/clangd.html
 [omnisharp]: https://github.com/OmniSharp/omnisharp-roslyn

--- a/eglot.el
+++ b/eglot.el
@@ -222,7 +222,11 @@ automatically)."
                                 (vimrc-mode . ("vim-language-server" "--stdio"))
                                 ((python-mode python-ts-mode)
                                  . ,(eglot-alternatives
-                                     '("pylsp" "pyls" ("pyright-langserver" "--stdio") "jedi-language-server" "ruff-lsp")))
+                                     '("pylsp" "pyls"
+                                       ("basedpyright-langserver" "--stdio")
+                                       ("pyright-langserver" "--stdio")
+                                       "jedi-language-server"
+                                       "ruff-lsp")))
                                 ((js-json-mode json-mode json-ts-mode)
                                  . ,(eglot-alternatives '(("vscode-json-language-server" "--stdio")
                                                           ("vscode-json-languageserver" "--stdio")


### PR DESCRIPTION
There is a new LSP server for Python, fork of unmaintained `pyright` LSP server.

The goal of this new LSP server is to also include features delegated to the closed source `pylance` LSP server.