### PR TITLE
readme: add ghdl-language-server for vhdl.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ variable, where you can [easily add your own servers][manual].
 * Rust's [rust-analyzer][rust-analyzer]
 * Scala's [metals][metals]
 * TeX/LaTeX's [Digestif][digestif] ot [texlab][texlab]
+* VHDL's [ghdl-language-server][ghdl-language-server]
 * VimScript's [vim-language-server][vim-language-server]
 * YAML's [yaml-language-server][yaml-language-server]
 * Zig's [zls][zls]
@@ -306,6 +307,7 @@ for the request form, and we'll send it to you.
 [digestif]: https://github.com/astoff/digestif
 [texlab]: https://github.com/latex-lsp/texlab
 [vim-language-server]: https://github.com/iamcco/vim-language-server
+[ghdl-language-server]: https://github.com/ghdl/ghdl-language-server
 [yaml-language-server]: https://github.com/redhat-developer/yaml-language-server
 [zls]: https://github.com/zigtools/zls
 


### PR DESCRIPTION
Ghdl is a simulator, synthesis and lsp for vhdl.

It is compatible with eglot.