### PR TITLE
Fix invocation of cmake language servers

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -244,7 +244,7 @@ automatically)."
   ;; `eglot.el' is installed via GNU ELPA in an older Emacs.
   `(((rust-ts-mode rust-mode) . ("rust-analyzer"))
     ((cmake-mode cmake-ts-mode)
-     . ,(eglot-alternatives '((("neocmakelsp" "--stdio") "cmake-language-server"))))
+     . ,(eglot-alternatives '(("neocmakelsp" "--stdio") "cmake-language-server")))
     (vimrc-mode . ("vim-language-server" "--stdio"))
     ((python-mode python-ts-mode)
      . ,(eglot-alternatives


### PR DESCRIPTION
In the master branch, when using either of the cmake language servers with Eglot, it gives an error:

`[eglot] (warning) Wrong type argument: stringp, ("neocmakelsp" "--stdio")`

This problem was introduced in 07bbfea901a71a89d54129ee690e71e9a79b7720 in emacs master branch.
https://github.com/emacs-mirror/emacs/commit/07bbfea901a71a89d54129ee690e71e9a79b7720