### PR TITLE
For Erlang, erlang_ls has been replaced by elp

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ variable, where you can [easily add your own servers][manual].
 * Dockerfile's [docker-langserver][docker-langserver]
 * Elixir's [elixir-ls][elixir-ls]
 * Elm's [elm-language-server][elm-language-server]
-* Erlang's [erlang_ls][erlang_ls]
+* Erlang's [erlang-language-platform][erlang-language-platform]
 * Fortran's [fortls][fortls]
 * Futhark's [futhark lsp][futhark-lsp]
 * Go's [gopls][gopls]
@@ -348,7 +348,7 @@ for the request form, and we'll send it to you.
 [docker-langserver]: https://github.com/rcjsuen/dockerfile-language-server-nodejs
 [emacs-lsp-plugins]: https://github.com/emacs-lsp
 [emacs-lsp]: https://github.com/emacs-lsp/lsp-mode
-[erlang_ls]: https://github.com/erlang-ls/erlang_ls
+[erlang-language-platform]: https://github.com/WhatsApp/erlang-language-platform
 [gnuelpa]: https://elpa.gnu.org/packages/eglot.html
 [gnudevelelpa]: https://elpa.gnu.org/devel/eglot.html
 [melpa]: https://melpa.org/#/eglot

--- a/eglot.el
+++ b/eglot.el
@@ -302,7 +302,7 @@ automatically)."
     (racket-mode . ("racket" "-l" "racket-langserver"))
     ((latex-mode plain-tex-mode context-mode texinfo-mode bibtex-mode tex-mode)
      . ,(eglot-alternatives '("digestif" "texlab")))
-    (erlang-mode . ("erlang_ls" "--transport" "stdio"))
+    (erlang-mode . ("elp" "server"))
     ((yaml-ts-mode yaml-mode) . ("yaml-language-server" "--stdio"))
     (nix-mode . ,(eglot-alternatives '("nil" "rnix-lsp" "nixd")))
     (nickel-mode . ("nls"))


### PR DESCRIPTION
erlang_ls has been archived, in favour of erlang-language-platform

https://github.com/erlang-ls/erlang_ls
https://github.com/WhatsApp/erlang-language-platform

Update the README for this, and propose a change to eglot.el