### PR TITLE
Don't mangle non-file URIs with expand-file-name

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -1239,6 +1239,16 @@ object."
           (concat remote-prefix normalized))
       uri)))
 
+(defsubst eglot--uri-p (path)
+  "Return non-nil if PATH is a URI rather than a file-system path.
+Detects non-file URIs returned unchanged by `eglot-uri-to-path',
+such as \"jar:file:///...\".  These must not be passed to
+`expand-file-name', which would mangle them into bogus local paths."
+  (let ((scheme (url-type (url-generic-parse-url path))))
+    ;; Real URI schemes are always longer than 1 character.
+    ;; A single-character "scheme" is a Windows drive letter (e.g. C:).
+    (and scheme (> (length scheme) 1))))
+
 (cl-defun eglot-path-to-uri (path &key truenamep)
   "Convert PATH, a file name, to LSP URI string and return it.
 TRUENAMEP indicated PATH is already a truename."
@@ -2411,7 +2421,9 @@ the previous reports for TOKEN.")
                                        eglot--servers-by-project))
                   (and eglot-extend-to-xref
                        buffer-file-name
-                       (gethash (expand-file-name buffer-file-name)
+                       (gethash (if (eglot--uri-p buffer-file-name)
+                                    buffer-file-name
+                                  (expand-file-name buffer-file-name))
                                 eglot--servers-by-xrefed-file)))))))
 
 (defun eglot--current-server-or-lose ()
@@ -3378,7 +3390,8 @@ to eventually report the corresponding Flymake conversions of each
 object.  The originator of this \"push\" is usually either regular
 `textDocument/publishDiagnostics' or an experimental
 `$/streamDiagnostics' notification."
-  (if-let* ((path (expand-file-name (eglot-uri-to-path uri)))
+  (if-let* ((path (let ((p (eglot-uri-to-path uri)))
+                    (if (eglot--uri-p p) p (expand-file-name p))))
             (buffer (eglot--find-buffer-visiting server path)))
       (with-current-buffer buffer
         (if (and version (/= version eglot--docver))
@@ -3539,7 +3552,8 @@ Try to visit the target file for a richer summary line."
                  (start-pos (cl-getf start :character))
                  (end-pos (cl-getf (cl-getf range :end) :character)))
             (list name line start-pos (- end-pos start-pos)))))))
-    (setf (gethash (expand-file-name file) eglot--servers-by-xrefed-file)
+    (setf (gethash (if (eglot--uri-p file) file (expand-file-name file))
+                   eglot--servers-by-xrefed-file)
           (eglot--current-server-or-lose))
     (xref-make-match summary (xref-make-file-location file line column) length)))
 


### PR DESCRIPTION
## Summary

When `eglot-uri-to-path` returns a non-file URI unchanged (e.g. `jar:file:///path.jar!/Foo.scala` from Metals, clojure-lsp, jdtls, etc.), three call sites pass it to `expand-file-name`, which treats the URI as a relative path and prepends `default-directory`:

```
jar:file:///home/user/.m2/foo.jar!/com/Bar.scala
→ /project/dir/jar:file:/home/user/.m2/foo.jar!/com/Bar.scala
```

This is inconsistent with the approach established in bug#58790: eglot passes non-file URIs through for `file-name-handler-alist` handlers (e.g. [jarchive](https://elpa.gnu.org/packages/jarchive.html)) to deal with. The bug is that eglot's own code mangles the URIs before they ever reach any handler.

### Fix

Add `eglot--uri-p` to detect non-file URIs (by checking if `url-type` returns a scheme longer than 1 character, to exclude Windows drive letters), and guard three `expand-file-name` call sites:

- `eglot--xref-make-match` — hash store into `eglot--servers-by-xrefed-file`
- `eglot-current-server` — hash lookup from `eglot--servers-by-xrefed-file`
- `eglot--flymake-handle-push` — path for buffer visiting + diagnostics

### Observed symptoms

With Metals (Scala LSP), following `xref-find-definitions` to a symbol in a dependency source jar:

1. The opened buffer gets a mangled `buffer-file-name` with the project dir prepended to the `jar:file:` URI
2. Eglot sends `textDocument/didOpen` with a fabricated `file:///...jar%3Afile%3A/...` URI
3. The language server crashes with `NoSuchFileException` for the bogus path
4. `eglot-extend-to-xref` silently fails because the hash key stored by `eglot--xref-make-match` (mangled) doesn't match the lookup key in `eglot-current-server`

### Related

- #661 — original discussion of jar:file: URI handling
- bug#58790 — the fix that made `eglot-uri-to-path` pass non-file URIs through

🤖 Generated with [Claude Code](https://claude.com/claude-code)